### PR TITLE
PM-2903: Storage and RocksDB interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ mill --watch metronome[2.13.4].rocksdb.test
 To run a single test class, use the `.single` method with the full path to the spec:
 
 ```console
-mill __.checkpointing.app.test.single io.iohk.metronome.app.config.ConfigSpec
+mill __.storage.test.single io.iohk.metronome.storage.KVStoreStateSpec
 ```
 
 ### Formatting the codebase

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To run tests, use the wild cards again and the `.test` postix:
 
 ```console
 mill __.test
-mill metronome[2.12.10].checkpointing.app.test.test
+mill --watch metronome[2.13.4].rocksdb.test
 ```
 
 To run a single test class, use the `.single` method with the full path to the spec:

--- a/build.sc
+++ b/build.sc
@@ -25,12 +25,14 @@ object VersionOf {
   val `scodec-bits` = "1.1.12"
 }
 
-object metronome extends Cross[MetronomeModule]("2.12.10", "2.13.4")
+// Using 2.12.13 instead of 2.12.10 to access @nowarn, to disable certain deperaction
+// warnings that come up in 2.13 but are too awkward to work around.
+object metronome extends Cross[MetronomeModule]("2.12.13", "2.13.4")
 
 class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
 
-  // Get rid of the `metronome-2.12.10-` part from the artifact name. The JAR name suffix will shows the Scala version.
-  // Check with `mill show metronome[2.12.10].__.artifactName` or `mill __.publishLocal`.
+  // Get rid of the `metronome-2.13.4-` part from the artifact name. The JAR name suffix will shows the Scala version.
+  // Check with `mill show metronome[2.13.4].__.artifactName` or `mill __.publishLocal`.
   private def removeCrossVersion(artifactName: String): String =
     "metronome-" + artifactName.split("-").drop(2).mkString("-")
 
@@ -86,7 +88,8 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
             "-language:higherKinds",
             "-language:postfixOps"
           )
-        case "2.13" => Nil
+        case "2.13" =>
+          Seq()
       }
     }
 

--- a/build.sc
+++ b/build.sc
@@ -11,16 +11,18 @@ import mill.contrib.versionfile.VersionFileModule
 object versionFile extends VersionFileModule
 
 object VersionOf {
-  val cats         = "2.3.1"
-  val config       = "1.4.1"
-  val logback      = "1.2.3"
-  val monix        = "3.3.0"
-  val prometheus   = "0.10.0"
-  val rocksdb      = "6.15.2"
-  val scalacheck   = "1.15.2"
-  val scalalogging = "3.9.2"
-  val scalatest    = "3.2.5"
-  val scalanet     = "0.7.0"
+  val cats          = "2.3.1"
+  val config        = "1.4.1"
+  val logback       = "1.2.3"
+  val monix         = "3.3.0"
+  val prometheus    = "0.10.0"
+  val rocksdb       = "6.15.2"
+  val scalacheck    = "1.15.2"
+  val scalalogging  = "3.9.2"
+  val scalatest     = "3.2.5"
+  val scalanet      = "0.7.0"
+  val `scodec-core` = "1.11.7"
+  val `scodec-bits` = "1.1.12"
 }
 
 object metronome extends Cross[MetronomeModule]("2.12.10", "2.13.4")
@@ -89,7 +91,15 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
   }
 
   /** Storage abstractions, e.g. a generic key-value store. */
-  object storage extends SubModule
+  object storage extends SubModule {
+    override def ivyDeps = super.ivyDeps() ++ Agg(
+      ivy"org.typelevel::cats-free:${VersionOf.cats}",
+      ivy"org.scodec::scodec-bits:${VersionOf.`scodec-bits`}",
+      ivy"org.scodec::scodec-core:${VersionOf.`scodec-core`}"
+    )
+
+    object test extends TestModule
+  }
 
   /** Emit trace events, abstracting away logs and metrics.
     *

--- a/build.sc
+++ b/build.sc
@@ -66,10 +66,37 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       ivy"org.typelevel::cats-effect:${VersionOf.cats}"
     )
 
+    override def scalacOptions = Seq(
+      "-unchecked",
+      "-deprecation",
+      "-feature",
+      "-Xfatal-warnings",
+      "-encoding",
+      "utf-8"
+    ) ++ {
+      crossScalaVersion.take(4) match {
+        case "2.12" =>
+          // These options don't work well with 2.13
+          Seq(
+            "-Xlint:unsound-match",
+            "-Ywarn-inaccessible",
+            "-Ywarn-unused-import",
+            "-Ypartial-unification", // Required for the `>>` syntax.
+            "-Ywarn-value-discard",
+            "-language:higherKinds",
+            "-language:postfixOps"
+          )
+        case "2.13" => Nil
+      }
+    }
+
     // `extends Tests` uses the context of the module in which it's defined
     trait TestModule extends Tests {
       override def artifactName =
         removeCrossVersion(super.artifactName())
+
+      override def scalacOptions =
+        SubModule.this.scalacOptions
 
       override def testFrameworks =
         Seq("org.scalatest.tools.Framework")

--- a/build.sc
+++ b/build.sc
@@ -72,9 +72,10 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       "-unchecked",
       "-deprecation",
       "-feature",
-      "-Xfatal-warnings",
       "-encoding",
-      "utf-8"
+      "utf-8",
+      "-Xfatal-warnings",
+      "-Ywarn-value-discard"
     ) ++ {
       crossScalaVersion.take(4) match {
         case "2.12" =>
@@ -84,7 +85,6 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
             "-Ywarn-inaccessible",
             "-Ywarn-unused-import",
             "-Ypartial-unification", // Required for the `>>` syntax.
-            "-Ywarn-value-discard",
             "-language:higherKinds",
             "-language:postfixOps"
           )
@@ -102,7 +102,10 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
         SubModule.this.scalacOptions
 
       override def testFrameworks =
-        Seq("org.scalatest.tools.Framework")
+        Seq(
+          "org.scalatest.tools.Framework",
+          "org.scalacheck.ScalaCheckFramework"
+        )
 
       // It may be useful to see logs in tests.
       override def moduleDeps: Seq[JavaModule] =

--- a/build.sc
+++ b/build.sc
@@ -255,6 +255,10 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       ivy"org.rocksdb:rocksdbjni:${VersionOf.rocksdb}"
     )
 
-    object test extends TestModule
+    object test extends TestModule {
+      override def ivyDeps = super.ivyDeps() ++ Agg(
+        ivy"io.monix::monix:${VersionOf.monix}"
+      )
+    }
   }
 }

--- a/metronome/rocksdb/src/io/iohk/metronome/rocksdb/RocksDBStore.scala
+++ b/metronome/rocksdb/src/io/iohk/metronome/rocksdb/RocksDBStore.scala
@@ -92,7 +92,7 @@ class RocksDBStore[F[_]: Sync](
     for {
       kbs <- encode(op.key)(op.keyCodec)
       mvbs <- Sync[F].delay[Option[Array[Byte]]] {
-        Option(db.get(handles(op.namespace), kbs))
+        Option(db.get(handles(op.namespace), readOptions, kbs))
       }
       mv <- mvbs match {
         case None =>

--- a/metronome/rocksdb/src/io/iohk/metronome/rocksdb/RocksDBStore.scala
+++ b/metronome/rocksdb/src/io/iohk/metronome/rocksdb/RocksDBStore.scala
@@ -1,0 +1,121 @@
+package io.iohk.metronome.rocksdb
+
+import cats._
+import cats.implicits._
+import cats.data.StateT
+import cats.effect.{Resource, Sync}
+import io.iohk.metronome.storage.{KVStore, KVStoreOp}
+import io.iohk.metronome.storage.KVStoreOp.{Put, Get, Delete}
+import org.rocksdb._
+import scodec.Codec
+import scodec.bits.BitVector
+
+class RocksDBStore[F[_]: Sync](
+    db: RocksDB,
+    handles: Map[RocksDBStore.Namespace, ColumnFamilyHandle],
+    readOptions: ReadOptions
+) {
+  import RocksDBStore.{Namespace, DBQuery}
+
+  type BatchState        = (WriteOptions, WriteBatch)
+  type DBQueryState[A]   = ({ type L[A] = StateT[F, BatchState, A] })#L[A]
+  type KVNamespacedOp[A] = ({ type L[A] = KVStoreOp[Namespace, A] })#L[A]
+
+  /** Collect writes in a batch, until we either get to the end, or there's a read.
+    * This way writes are atomic, and reads can see their effect.
+    *
+    * In the next version of RocksDB we can use transactions to make reads and writes
+    * run in isolation.
+    */
+  private val batchingCompiler: KVNamespacedOp ~> DBQueryState =
+    new (KVNamespacedOp ~> DBQueryState) {
+      def apply[A](fa: KVNamespacedOp[A]): DBQueryState[A] =
+        fa match {
+          case op @ Put(n, k, v) =>
+            StateT.modifyF { case (opts, batch) =>
+              for {
+                kbs <- encode(k)(op.keyCodec)
+                vbs <- encode(v)(op.valueCodec)
+                _ = batch.put(handles(n), kbs, vbs)
+              } yield (opts, batch)
+            }
+
+          case op @ Get(n, k) =>
+            StateT.modifyF(executeBatch).flatMap { _ =>
+              StateT.liftF {
+                for {
+                  kbs  <- encode(k)(op.keyCodec)
+                  mvbs <- Sync[F].delay(Option(db.get(handles(n), kbs)))
+                  mv <- mvbs match {
+                    case None =>
+                      none.pure[F]
+
+                    case Some(bytes) =>
+                      decode(bytes)(op.valueCodec).map(_.some)
+                  }
+                } yield mv
+              }
+            }
+
+          case op @ Delete(n, k) =>
+            StateT.modifyF { case (opts, batch) =>
+              for {
+                kbs <- encode(k)(op.keyCodec)
+                _ = batch.delete(handles(n), kbs)
+              } yield (opts, batch)
+            }
+        }
+    }
+
+  private def executeBatch(state: BatchState): F[BatchState] = state match {
+    case (opts, batch) if batch.hasPut() || batch.hasDelete() =>
+      Sync[F].delay {
+        db.write(opts, batch)
+        batch.clear()
+        (opts, batch)
+      }
+    case unchanged =>
+      unchanged.pure[F]
+  }
+
+  private def encode[T](value: T)(implicit ev: Codec[T]): F[Array[Byte]] =
+    Sync[F].fromTry(ev.encode(value).map(_.toByteArray).toTry)
+
+  private def decode[T](bytes: Array[Byte])(implicit ev: Codec[T]): F[T] =
+    Sync[F].fromTry(ev.decodeValue(BitVector(bytes)).toTry)
+
+  private def fromAutoCloseable[R <: AutoCloseable](mk: => R): Resource[F, R] =
+    Resource.fromAutoCloseable[F, R](Sync[F].delay(mk))
+
+  /** Execute a program that writes and potentially reads as well. */
+  def update[A](program: KVStore[Namespace, A]): F[A] = {
+    val compilerR = for {
+      opts  <- fromAutoCloseable(new WriteOptions())
+      batch <- fromAutoCloseable(new WriteBatch())
+    } yield (opts, batch)
+
+    compilerR.use { state =>
+      program.foldMap(batchingCompiler).run(state).flatMap { case (state, a) =>
+        executeBatch(state).as(a)
+      }
+    }
+  }
+
+  /** Execute a program that only has reads. */
+  def query[A](program: KVStore[Namespace, A]): F[A] = ???
+}
+
+object RocksDBStore {
+  type Namespace = IndexedSeq[Byte]
+
+  /** Database operations may fail due to a couple of reasons:
+    * - database connection issues
+    * - obsolete format stored, codec unable to read data
+    *
+    * But it's not expected, so just using `F[A]` for now,
+    * rather than `EitherT[F, Throwable, A]`.
+    */
+  type DBQuery[F[_], A] = F[A]
+
+  def apply[F[_]: Sync](): Resource[F, RocksDBStore[F]] = ???
+}

--- a/metronome/rocksdb/src/io/iohk/metronome/rocksdb/RocksDBStore.scala
+++ b/metronome/rocksdb/src/io/iohk/metronome/rocksdb/RocksDBStore.scala
@@ -11,20 +11,30 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import org.rocksdb.{
   RocksDB,
   WriteBatch,
-  ColumnFamilyHandle,
   WriteOptions,
-  ReadOptions
+  ReadOptions,
+  Options,
+  DBOptions,
+  ColumnFamilyOptions,
+  ColumnFamilyDescriptor,
+  ColumnFamilyHandle,
+  BlockBasedTableConfig,
+  BloomFilter,
+  CompressionType,
+  ClockCache
 }
 import scodec.Codec
 import scodec.bits.BitVector
+import scala.collection.mutable
+import java.nio.file.Path
 
 class RocksDBStore[F[_]: Sync](
     db: RocksDB,
-    handles: Map[RocksDBStore.Namespace, ColumnFamilyHandle],
     readOptions: ReadOptions,
-    rwlock: ReentrantReadWriteLock
+    rwlock: ReentrantReadWriteLock,
+    handles: Map[RocksDBStore.Namespace, ColumnFamilyHandle]
 ) {
-  import RocksDBStore.{Namespace, DBQuery}
+  import RocksDBStore.{Namespace, DBQuery, autoCloseableR}
 
   type BatchEnv          = (WriteOptions, WriteBatch)
   type Batch[A]          = ({ type L[A] = ReaderT[F, BatchEnv, A] })#L[A]
@@ -134,15 +144,12 @@ class RocksDBStore[F[_]: Sync](
   private def decode[T](bytes: Array[Byte])(implicit ev: Codec[T]): F[T] =
     Sync[F].fromTry(ev.decodeValue(BitVector(bytes)).toTry)
 
-  private def fromAutoCloseable[R <: AutoCloseable](mk: => R): Resource[F, R] =
-    Resource.fromAutoCloseable[F, R](Sync[F].delay(mk))
-
   private def runWithBatchingNoLock[A](
       program: KVStore[Namespace, A]
   ): DBQuery[F, A] = {
     val env = for {
-      opts  <- fromAutoCloseable(new WriteOptions())
-      batch <- fromAutoCloseable(new WriteBatch())
+      opts  <- autoCloseableR(new WriteOptions())
+      batch <- autoCloseableR(new WriteBatch())
     } yield (opts, batch)
 
     env.use {
@@ -192,5 +199,146 @@ object RocksDBStore {
     */
   type DBQuery[F[_], A] = F[A]
 
-  def apply[F[_]: Sync](): Resource[F, RocksDBStore[F]] = ???
+  case class Config(
+      path: Path,
+      createIfMissing: Boolean,
+      paranoidChecks: Boolean,
+      maxThreads: Int,
+      maxOpenFiles: Int,
+      verifyChecksums: Boolean,
+      levelCompaction: Boolean,
+      blockSizeBytes: Long,
+      blockCacheSizeBytes: Long
+  )
+  object Config {
+    def default(path: Path): Config =
+      Config(
+        path = path,
+        // Create DB data directory if it's missing
+        createIfMissing = true,
+        // Should the DB raise an error as soon as it detects an internal corruption
+        paranoidChecks = true,
+        maxThreads = 1,
+        maxOpenFiles = 32,
+        // Force checksum verification of all data that is read from the file system on behalf of a particular read.
+        verifyChecksums = true,
+        // In this mode, size target of levels are changed dynamically based on size of the last level.
+        // https://rocksdb.org/blog/2015/07/23/dynamic-level.html
+        levelCompaction = true,
+        // Approximate size of user data packed per block (16 * 1024)
+        blockSizeBytes = 16384,
+        // Amount of cache in bytes that will be used by RocksDB (32 * 1024 * 1024)
+        blockCacheSizeBytes = 33554432
+      )
+  }
+
+  def apply[F[_]: Sync](
+      config: Config,
+      namespaces: Seq[Namespace]
+  ): Resource[F, RocksDBStore[F]] = {
+    import scala.collection.JavaConverters._
+
+    // There is a specific order for closing RocksDB with column families described in
+    // https://github.com/facebook/rocksdb/wiki/RocksJava-Basics#opening-a-database-with-column-families
+    // 1. Free all column families handles
+    // 2. Free DB and DB options
+    // 3. Free column families options
+    // So they are created in the opposite order.
+    for {
+      _ <- Resource.liftF[F, Unit](Sync[F].delay {
+        RocksDB.loadLibrary()
+      })
+
+      tableConf <- Resource.pure[F, BlockBasedTableConfig] {
+        mkTableConfig(config)
+      }
+
+      cfOpts <- autoCloseableR[F, ColumnFamilyOptions] {
+        new ColumnFamilyOptions()
+          .setCompressionType(CompressionType.LZ4_COMPRESSION)
+          .setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION)
+          .setLevelCompactionDynamicLevelBytes(config.levelCompaction)
+          .setTableFormatConfig(tableConf)
+      }
+
+      cfDescriptors =
+        new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpts) +:
+          namespaces.map(n => new ColumnFamilyDescriptor(n.toArray, cfOpts))
+
+      dbOpts <- autoCloseableR[F, DBOptions] {
+        new DBOptions()
+          .setCreateIfMissing(config.createIfMissing)
+          .setParanoidChecks(config.paranoidChecks)
+          .setMaxOpenFiles(config.maxOpenFiles)
+          .setIncreaseParallelism(config.maxThreads)
+          .setCreateMissingColumnFamilies(true)
+      }
+
+      readOpts <- autoCloseableR[F, ReadOptions] {
+        new ReadOptions().setVerifyChecksums(config.verifyChecksums)
+      }
+
+      // The handles will be filled as the database is opened.
+      columnFamilyHandleBuffer = mutable.Buffer.empty[ColumnFamilyHandle]
+
+      db <- autoCloseableR[F, RocksDB] {
+        RocksDB.open(
+          dbOpts,
+          config.path.toString,
+          cfDescriptors.asJava,
+          columnFamilyHandleBuffer.asJava
+        )
+      }
+
+      columnFamilyHandles <- Resource.make(
+        Sync[F].delay {
+          assert(columnFamilyHandleBuffer.size == namespaces.size)
+          (namespaces zip columnFamilyHandleBuffer).toMap
+        }
+      ) { handles =>
+        Sync[F].delay(handles.values.foreach(_.close()))
+      }
+
+      store = new RocksDBStore[F](
+        db,
+        readOpts,
+        new ReentrantReadWriteLock(),
+        columnFamilyHandles
+      )
+
+    } yield store
+  }
+
+  def destroy[F[_]: Sync](
+      config: Config
+  ): F[Unit] = {
+    autoCloseableR[F, Options] {
+      new Options()
+        .setCreateIfMissing(config.createIfMissing)
+        .setParanoidChecks(config.paranoidChecks)
+        .setCompressionType(CompressionType.LZ4_COMPRESSION)
+        .setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION)
+        .setLevelCompactionDynamicLevelBytes(config.levelCompaction)
+        .setMaxOpenFiles(config.maxOpenFiles)
+        .setIncreaseParallelism(config.maxThreads)
+        .setTableFormatConfig(mkTableConfig(config))
+    }.use { options =>
+      Sync[F].delay {
+        RocksDB.destroyDB(config.path.toString, options)
+      }
+    }
+  }
+
+  private def mkTableConfig(config: Config): BlockBasedTableConfig =
+    new BlockBasedTableConfig()
+      .setBlockSize(config.blockSizeBytes)
+      .setBlockCache(new ClockCache(config.blockCacheSizeBytes))
+      .setCacheIndexAndFilterBlocks(true)
+      .setPinL0FilterAndIndexBlocksInCache(true)
+      .setFilterPolicy(new BloomFilter(10, false))
+
+  private def autoCloseableR[F[_]: Sync, R <: AutoCloseable](
+      mk: => R
+  ): Resource[F, R] =
+    Resource.fromAutoCloseable[F, R](Sync[F].delay(mk))
 }

--- a/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
+++ b/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
@@ -1,17 +1,19 @@
 package io.iohk.metronome.rocksdb
 
+import cats.implicits._
 import cats.effect.Resource
-import io.iohk.metronome.storage.KVStoreState
+import io.iohk.metronome.storage.{KVStoreState, KVStore}
 import java.nio.file.Files
 import monix.eval.Task
 import org.scalacheck.commands.Commands
-import org.scalacheck.{Properties, Gen}
+import org.scalacheck.{Properties, Gen, Prop, Test, Arbitrary}
 import org.scalacheck.Arbitrary.arbitrary
-// import org.scalacheck.Prop
-// import scala.util.{Try, Success}
+import scala.util.{Try, Success}
 import scala.concurrent.duration._
 import scala.annotation.nowarn
-import org.scalacheck.Test
+import io.iohk.metronome.storage.KVCollection
+import scodec.bits.ByteVector
+import scodec.codecs.implicits._
 
 // https://github.com/typelevel/scalacheck/blob/master/doc/UserGuide.md#stateful-testing
 // https://github.com/typelevel/scalacheck/blob/master/examples/commands-redis/src/test/scala/CommandsRedis.scala
@@ -19,7 +21,7 @@ import org.scalacheck.Test
 object RocksDBStoreSpec extends Properties("RocksDBStoreCommands") {
 
   override def overrideParameters(p: Test.Parameters): Test.Parameters =
-    p.withMinSuccessfulTests(5).withMaxSize(100)
+    p.withMinSuccessfulTests(10).withMaxSize(100)
 
   property("RocksDBStoreSpec") = RocksDBStoreCommands.property()
 
@@ -31,13 +33,36 @@ object RocksDBStoreCommands extends Commands {
   // The in-memory implementation is our reference execution model.
   object InMemoryKVS extends KVStoreState[Namespace]
 
+  // Some structured data to be stored in the database.
+  case class TestRecord(id: ByteVector, name: String, value: Int)
+
   // Symbolic state of the test.
   case class Model(
       // Support opening/closing the database to see if it can read back the files it has created.
       isConnected: Boolean,
-      namespaces: Seq[Namespace],
-      store: InMemoryKVS.Store
-  )
+      namespaces: IndexedSeq[Namespace],
+      store: InMemoryKVS.Store,
+      deleted: Map[Namespace, Set[Any]],
+      // Some collections so we have typed access.
+      coll0: KVCollection[Namespace, String, Int],
+      coll1: KVCollection[Namespace, Int, ByteVector],
+      coll2: KVCollection[Namespace, ByteVector, TestRecord]
+  ) {
+
+    def storeOf(coll: Coll): Map[Any, Any] =
+      store.getOrElse(namespaces(coll.idx), Map.empty)
+
+    def nonEmptyColls: List[Coll] =
+      Colls.filter(c => storeOf(c).nonEmpty)
+  }
+  sealed trait Coll {
+    def idx: Int
+  }
+  case object Coll0 extends Coll { def idx = 0 }
+  case object Coll1 extends Coll { def idx = 1 }
+  case object Coll2 extends Coll { def idx = 2 }
+
+  val Colls = List(Coll0, Coll1, Coll2)
 
   case class Allocated[T](value: T, release: Task[Unit])
 
@@ -108,12 +133,17 @@ object RocksDBStoreCommands extends Commands {
   /** Initialise a fresh model state. */
   override def genInitialState: Gen[State] =
     for {
-      n  <- Gen.choose(1, 10)
+      n  <- Gen.choose(3, 10)
       ns <- Gen.listOfN(n, arbitrary[Array[Byte]])
+      namespaces = ns.map(_.toIndexedSeq).toIndexedSeq
     } yield Model(
       isConnected = false,
-      namespaces = ns.map(_.toIndexedSeq),
-      store = Map.empty
+      namespaces = namespaces,
+      store = Map.empty,
+      deleted = Map.empty,
+      coll0 = new KVCollection[Namespace, String, Int](namespaces(0)),
+      coll1 = new KVCollection[Namespace, Int, ByteVector](namespaces(1)),
+      coll2 = new KVCollection[Namespace, ByteVector, TestRecord](namespaces(2))
     )
 
   /** Produce a Command based on the current model state. */
@@ -121,8 +151,200 @@ object RocksDBStoreCommands extends Commands {
     if (!state.isConnected) Gen.const(ToggleConnected)
     else
       Gen.frequency(
+        (10, genProgram(state)),
         (1, Gen.const(ToggleConnected))
       )
+
+  /** Generate a */
+  def genProgram(state: State): Gen[RunProgram] =
+    for {
+      batching <- arbitrary[Boolean]
+      n        <- Gen.choose(0, 10)
+      ops <- Gen.listOfN(
+        n,
+        Gen.oneOf(
+          genPut(state),
+          genPutExisting(state),
+          genDel(state),
+          genGet(state),
+          genGetExisting(state)
+        )
+      )
+      program = ops.toList.sequence
+    } yield RunProgram(batching, program)
+
+  /** Pick a collection. */
+  implicit val arbColl: Arbitrary[Coll] = Arbitrary {
+    Gen.oneOf(Coll0, Coll1, Coll2)
+  }
+
+  implicit val arbByteVector: Arbitrary[ByteVector] = Arbitrary {
+    arbitrary[Array[Byte]].map(ByteVector(_))
+  }
+
+  implicit val arbTestRecord: Arbitrary[TestRecord] = Arbitrary {
+    for {
+      id    <- arbitrary[ByteVector]
+      name  <- arbitrary[String]
+      value <- arbitrary[Int]
+    } yield TestRecord(id, name, value)
+  }
+
+  def genPut(state: State): Gen[KVStore[Namespace, Any]] =
+    arbitrary[Coll] flatMap {
+      case Coll0 =>
+        for {
+          k <- arbitrary[String]
+          v <- arbitrary[Int]
+        } yield state.coll0.put(k, v)
+
+      case Coll1 =>
+        for {
+          k <- arbitrary[Int]
+          v <- arbitrary[ByteVector]
+        } yield state.coll1.put(k, v)
+
+      case Coll2 =>
+        for {
+          k <- arbitrary[ByteVector]
+          v <- arbitrary[TestRecord]
+        } yield state.coll2.put(k, v)
+    } map {
+      _.map(_.asInstanceOf[Any])
+    }
+
+  def genPutExisting(state: State): Gen[KVStore[Namespace, Any]] =
+    state.nonEmptyColls match {
+      case Nil =>
+        genPut(state)
+
+      case colls =>
+        for {
+          c <- Gen.oneOf(colls)
+          k <- Gen.oneOf(state.storeOf(c).keySet)
+          op <- c match {
+            case Coll0 =>
+              arbitrary[Int].map { v =>
+                state.coll0.put(k.asInstanceOf[String], v)
+              }
+
+            case Coll1 =>
+              arbitrary[ByteVector].map { v =>
+                state.coll1.put(k.asInstanceOf[Int], v)
+              }
+
+            case Coll2 =>
+              arbitrary[TestRecord].map { v =>
+                state.coll2.put(k.asInstanceOf[ByteVector], v)
+              }
+          }
+        } yield op.map(_.asInstanceOf[Any])
+    }
+
+  def genDel(state: State): Gen[KVStore[Namespace, Any]] =
+    arbitrary[Coll] flatMap {
+      case Coll0 =>
+        arbitrary[String].map(state.coll0.delete)
+
+      case Coll1 =>
+        arbitrary[Int].map(state.coll1.delete)
+
+      case Coll2 =>
+        arbitrary[ByteVector].map(state.coll2.delete)
+    } map {
+      _.map(_.asInstanceOf[Any])
+    }
+
+  def genDelExisting(state: State): Gen[KVStore[Namespace, Any]] =
+    state.nonEmptyColls match {
+      case Nil =>
+        genGet(state)
+
+      case colls =>
+        for {
+          c <- Gen.oneOf(colls)
+          k <- Gen.oneOf(state.storeOf(c).keySet)
+          op = c match {
+            case Coll0 =>
+              state.coll0.delete(k.asInstanceOf[String])
+
+            case Coll1 =>
+              state.coll1.delete(k.asInstanceOf[Int])
+
+            case Coll2 =>
+              state.coll2.delete(k.asInstanceOf[ByteVector])
+          }
+        } yield op.map(_.asInstanceOf[Any])
+    }
+
+  def genGet(state: State): Gen[KVStore[Namespace, Any]] =
+    arbitrary[Coll] flatMap {
+      case Coll0 =>
+        arbitrary[String].map(state.coll0.get)
+
+      case Coll1 =>
+        arbitrary[Int].map(state.coll1.get)
+
+      case Coll2 =>
+        arbitrary[ByteVector].map(state.coll2.get)
+    } map {
+      _.map(_.asInstanceOf[Any])
+    }
+
+  def genGetExisting(state: State): Gen[KVStore[Namespace, Any]] =
+    state.nonEmptyColls match {
+      case Nil =>
+        genGet(state)
+
+      case colls =>
+        for {
+          c <- Gen.oneOf(colls)
+          k <- Gen.oneOf(state.storeOf(c).keySet)
+          op = c match {
+            case Coll0 =>
+              state.coll0.get(k.asInstanceOf[String])
+
+            case Coll1 =>
+              state.coll1.get(k.asInstanceOf[Int])
+
+            case Coll2 =>
+              state.coll2.get(k.asInstanceOf[ByteVector])
+          }
+        } yield op.map(_.asInstanceOf[Any])
+    }
+
+  def genGetDeleted(state: State): Gen[KVStore[Namespace, Any]] = {
+    val hasDeletes =
+      Colls
+        .map { c =>
+          c -> state.namespaces(c.idx)
+        }
+        .filter { case (_, n) =>
+          state.deleted.getOrElse(n, Set.empty).nonEmpty
+        }
+
+    hasDeletes match {
+      case Nil =>
+        genGet(state)
+
+      case deletes =>
+        for {
+          cn <- Gen.oneOf(deletes)
+          (c, n) = cn
+          k <- Gen.oneOf(state.deleted(n))
+          op = c match {
+            case Coll0 =>
+              state.coll0.get(k.asInstanceOf[String])
+
+            case Coll1 =>
+              state.coll1.get(k.asInstanceOf[Int])
+
+            case Coll2 =>
+              state.coll2.get(k.asInstanceOf[ByteVector])
+          }
+        } yield op.map(_.asInstanceOf[Any])
+    }
+  }
 
   /** Open or close the database. */
   case object ToggleConnected extends UnitCommand {
@@ -148,5 +370,49 @@ object RocksDBStoreCommands extends Commands {
       isConnected = !state.isConnected
     )
     def postCondition(state: State, succeeded: Boolean) = succeeded
+  }
+
+  case class RunProgram(
+      batching: Boolean,
+      program: KVStore[Namespace, List[Any]]
+  ) extends Command {
+    // Collect all results from a batch of execution steps.
+    type Result = List[Any]
+
+    def run(sut: Sut): Result = {
+      val db = sut.maybeConnection.get.value
+      await {
+        if (batching) {
+          db.runWithBatching(program)
+        } else {
+          db.runWithoutBatching(program)
+        }
+      }
+    }
+
+    def preCondition(state: State): Boolean = state.isConnected
+
+    def nextState(state: State): State = {
+      val nextStore = InMemoryKVS.compile(program).runS(state.store).value
+
+      // Leave only what's still deleted. Add what's been deleted now.
+      val nextDeleted = state.deleted.map { case (n, ks) =>
+        val existing = nextStore.getOrElse(n, Map.empty).keySet
+        n -> ks.filterNot(existing)
+      } ++ state.store.map { case (n, kvs) =>
+        val existing = nextStore.getOrElse(n, Map.empty).keySet
+        n -> (kvs.keySet -- existing)
+      }
+
+      state.copy(
+        store = nextStore,
+        deleted = nextDeleted
+      )
+    }
+
+    def postCondition(state: Model, result: Try[Result]): Prop = {
+      val expected = InMemoryKVS.compile(program).runA(state.store).value
+      result == Success(expected)
+    }
   }
 }

--- a/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
+++ b/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
@@ -1,0 +1,95 @@
+package io.iohk.metronome.rocksdb
+
+import cats.effect.Resource
+import io.iohk.metronome.storage.KVStoreState
+import java.nio.file.Files
+import monix.eval.Task
+import org.scalacheck.commands.Commands
+import org.scalacheck.Gen
+import org.scalacheck.Arbitrary.arbitrary
+// import org.scalacheck.Prop
+// import scala.util.{Try, Success}
+import scala.concurrent.duration._
+import scala.annotation.nowarn
+
+// https://github.com/typelevel/scalacheck/blob/master/doc/UserGuide.md#stateful-testing
+// https://github.com/typelevel/scalacheck/tree/master/examples
+
+class RocksDBStoreSpec extends Commands {
+  import RocksDBStore.Namespace
+
+  object InMemoryKVS extends KVStoreState[Namespace]
+
+  case class AllocatedDatabase(
+      db: RocksDBStore[Task],
+      release: Task[Unit]
+  )
+
+  case class Model(
+      namespaces: Seq[Namespace],
+      store: InMemoryKVS.Store
+  )
+
+  type State = Model
+
+  type Sut = AllocatedDatabase
+
+  private def await[T](task: Task[T]): T = {
+    import monix.execution.Scheduler.Implicits.global
+    task.runSyncUnsafe(timeout = 10.seconds)
+  }
+
+  /** Run one database at any time. */
+  @nowarn // Traversable deprecated in 2.13
+  override def canCreateNewSut(
+      newState: State,
+      initSuts: Traversable[State],
+      runningSuts: Traversable[Sut]
+  ): Boolean =
+    initSuts.isEmpty && runningSuts.isEmpty
+
+  /** Start with an empty database. */
+  override def initialPreCondition(state: State): Boolean =
+    state.store.isEmpty
+
+  /** Create a new empty database. */
+  override def newSut(state: State): Sut = {
+    val res = for {
+      path <- Resource.make(Task {
+        Files.createTempDirectory("testdb").getFileName
+      }) { path =>
+        Task {
+          if (Files.exists(path)) Files.delete(path)
+        }
+      }
+
+      config = RocksDBStore.Config.default(path)
+
+      _ <- Resource.make(Task.unit) { _ =>
+        RocksDBStore.destroy[Task](config)
+      }
+
+      db <- RocksDBStore[Task](config, state.namespaces)
+    } yield db
+
+    await {
+      res.allocated.map { case (db, release) =>
+        AllocatedDatabase(db, release)
+      }
+    }
+  }
+
+  /** Release the database and all resources. */
+  override def destroySut(sut: Sut): Unit =
+    await(sut.release)
+
+  /** Initialise a fresh model state. */
+  override def genInitialState: Gen[State] =
+    for {
+      n  <- Gen.choose(1, 10)
+      ns <- Gen.listOfN(n, arbitrary[Array[Byte]])
+    } yield Model(ns.map(_.toIndexedSeq), Map.empty)
+
+  /** Produce a Command based on the current model state. */
+  def genCommand(state: State): Gen[Command] = ???
+}

--- a/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
+++ b/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
@@ -5,34 +5,50 @@ import io.iohk.metronome.storage.KVStoreState
 import java.nio.file.Files
 import monix.eval.Task
 import org.scalacheck.commands.Commands
-import org.scalacheck.Gen
+import org.scalacheck.{Properties, Gen}
 import org.scalacheck.Arbitrary.arbitrary
 // import org.scalacheck.Prop
 // import scala.util.{Try, Success}
 import scala.concurrent.duration._
 import scala.annotation.nowarn
+import org.scalacheck.Test
 
 // https://github.com/typelevel/scalacheck/blob/master/doc/UserGuide.md#stateful-testing
-// https://github.com/typelevel/scalacheck/tree/master/examples
+// https://github.com/typelevel/scalacheck/blob/master/examples/commands-redis/src/test/scala/CommandsRedis.scala
 
-class RocksDBStoreSpec extends Commands {
+object RocksDBStoreSpec extends Properties("RocksDBStoreCommands") {
+
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    p.withMinSuccessfulTests(5).withMaxSize(100)
+
+  property("RocksDBStoreSpec") = RocksDBStoreCommands.property()
+
+}
+
+object RocksDBStoreCommands extends Commands {
   import RocksDBStore.Namespace
 
+  // The in-memory implementation is our reference execution model.
   object InMemoryKVS extends KVStoreState[Namespace]
 
-  case class AllocatedDatabase(
-      db: RocksDBStore[Task],
-      release: Task[Unit]
-  )
-
+  // Symbolic state of the test.
   case class Model(
+      // Support opening/closing the database to see if it can read back the files it has created.
+      isConnected: Boolean,
       namespaces: Seq[Namespace],
       store: InMemoryKVS.Store
   )
 
-  type State = Model
+  case class Allocated[T](value: T, release: Task[Unit])
 
-  type Sut = AllocatedDatabase
+  class Database(
+      val namespaces: Seq[Namespace],
+      val config: Allocated[RocksDBStore.Config],
+      var maybeConnection: Option[Allocated[RocksDBStore[Task]]]
+  )
+
+  type State = Model
+  type Sut   = Database
 
   private def await[T](task: Task[T]): T = {
     import monix.execution.Scheduler.Implicits.global
@@ -50,13 +66,13 @@ class RocksDBStoreSpec extends Commands {
 
   /** Start with an empty database. */
   override def initialPreCondition(state: State): Boolean =
-    state.store.isEmpty
+    state.store.isEmpty && !state.isConnected
 
   /** Create a new empty database. */
   override def newSut(state: State): Sut = {
     val res = for {
       path <- Resource.make(Task {
-        Files.createTempDirectory("testdb").getFileName
+        Files.createTempDirectory("testdb")
       }) { path =>
         Task {
           if (Files.exists(path)) Files.delete(path)
@@ -68,28 +84,69 @@ class RocksDBStoreSpec extends Commands {
       _ <- Resource.make(Task.unit) { _ =>
         RocksDBStore.destroy[Task](config)
       }
-
-      db <- RocksDBStore[Task](config, state.namespaces)
-    } yield db
+    } yield config
 
     await {
-      res.allocated.map { case (db, release) =>
-        AllocatedDatabase(db, release)
+      res.allocated.map { case (config, release) =>
+        new Database(
+          state.namespaces,
+          Allocated(config, release),
+          maybeConnection = None
+        )
       }
     }
   }
 
   /** Release the database and all resources. */
   override def destroySut(sut: Sut): Unit =
-    await(sut.release)
+    await {
+      sut.maybeConnection
+        .fold(Task.unit)(_.release)
+        .guarantee(sut.config.release)
+    }
 
   /** Initialise a fresh model state. */
   override def genInitialState: Gen[State] =
     for {
       n  <- Gen.choose(1, 10)
       ns <- Gen.listOfN(n, arbitrary[Array[Byte]])
-    } yield Model(ns.map(_.toIndexedSeq), Map.empty)
+    } yield Model(
+      isConnected = false,
+      namespaces = ns.map(_.toIndexedSeq),
+      store = Map.empty
+    )
 
   /** Produce a Command based on the current model state. */
-  def genCommand(state: State): Gen[Command] = ???
+  def genCommand(state: State): Gen[Command] =
+    if (!state.isConnected) Gen.const(ToggleConnected)
+    else
+      Gen.frequency(
+        (1, Gen.const(ToggleConnected))
+      )
+
+  /** Open or close the database. */
+  case object ToggleConnected extends UnitCommand {
+    def run(sut: Sut) = {
+      sut.maybeConnection match {
+        case Some(connection) =>
+          await(connection.release)
+          sut.maybeConnection = None
+
+        case None =>
+          val connection = await {
+            RocksDBStore[Task](sut.config.value, sut.namespaces).allocated
+              .map { case (db, release) =>
+                Allocated(db, release)
+              }
+          }
+          sut.maybeConnection = Some(connection)
+      }
+    }
+
+    def preCondition(state: State) = true
+    def nextState(state: State) = state.copy(
+      isConnected = !state.isConnected
+    )
+    def postCondition(state: State, succeeded: Boolean) = succeeded
+  }
 }

--- a/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
+++ b/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
@@ -26,7 +26,7 @@ import scodec.codecs.implicits._
 object RocksDBStoreSpec extends Properties("RocksDBStoreCommands") {
 
   override def overrideParameters(p: Test.Parameters): Test.Parameters =
-    p.withMinSuccessfulTests(10).withMaxSize(100)
+    p.withMinSuccessfulTests(20).withMaxSize(100)
 
   // Equivalent to the in-memory model.
   property("equivalent") = RocksDBStoreCommands.property()
@@ -232,7 +232,7 @@ object RocksDBStoreCommands extends Commands {
       program = ops.toList.sequence
     } yield ProgramRW(program, batching)
 
-  /** Generate a sequence of writes and reads. */
+  /** Generate a read-only operations. */
   def genProgramRO(state: State): Gen[ProgramR] =
     for {
       n <- Gen.choose(0, 10)
@@ -409,11 +409,11 @@ object RocksDBStoreCommands extends Commands {
   def genRead(state: State): Gen[KVStoreRead[Namespace, Any]] =
     arbitrary[Coll] flatMap {
       case Coll0 =>
-        arbitrary[String].map(state.coll0.readonly.get)
+        arbitrary[String].map(state.coll0.read)
       case Coll1 =>
-        arbitrary[Int].map(state.coll1.readonly.get)
+        arbitrary[Int].map(state.coll1.read)
       case Coll2 =>
-        arbitrary[ByteVector].map(state.coll2.readonly.get)
+        arbitrary[ByteVector].map(state.coll2.read)
     } map {
       _.map(_.asInstanceOf[Any])
     }
@@ -429,11 +429,11 @@ object RocksDBStoreCommands extends Commands {
           k <- Gen.oneOf(state.storeOf(c).keySet)
           op = c match {
             case Coll0 =>
-              state.coll0.readonly.get(k.asInstanceOf[String])
+              state.coll0.read(k.asInstanceOf[String])
             case Coll1 =>
-              state.coll1.readonly.get(k.asInstanceOf[Int])
+              state.coll1.read(k.asInstanceOf[Int])
             case Coll2 =>
-              state.coll2.readonly.get(k.asInstanceOf[ByteVector])
+              state.coll2.read(k.asInstanceOf[ByteVector])
           }
         } yield op.map(_.asInstanceOf[Any])
     }

--- a/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
+++ b/metronome/rocksdb/test/src/io/iohk/metronome/rocksdb/RocksDBStoreSpec.scala
@@ -209,12 +209,12 @@ object RocksDBStoreCommands extends Commands {
   def genProgram(state: State): Gen[RunProgram] =
     for {
       batching <- arbitrary[Boolean]
-      n        <- Gen.choose(0, 20)
+      n        <- Gen.choose(0, 30)
       ops <- Gen.listOfN(
         n,
         Gen.frequency(
-          20 -> genPut(state),
-          20 -> genPutExisting(state),
+          10 -> genPut(state),
+          30 -> genPutExisting(state),
           5  -> genDel(state),
           15 -> genDelExisting(state),
           5  -> genGet(state),

--- a/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
@@ -1,0 +1,42 @@
+package io.iohk.metronome.storage
+
+import cats.free.Free
+import cats.free.Free.liftF
+import scodec.Codec
+
+/** Storage for a specific type of data, e.g. blocks, in a given namespace.
+  *
+  * We should be able to string together KVStore operations across multiple
+  * collections and execute them in one batch.
+  */
+class KVCollection[N, K: Codec, V: Codec](namespace: N) {
+
+  import KVStoreOp._
+
+  type KVNamespacedOp[A] = ({ type L[A] = KVStoreOp[N, A] })#L[A]
+
+  /** Put a value under a key. */
+  def put(key: K, value: V): KVStore[N, Unit] =
+    liftF[KVNamespacedOp, Unit](
+      Put[N, K, V](namespace, key, value)
+    )
+
+  /** Get a value by key, if it exists. */
+  def get(key: K): KVStore[N, Option[V]] =
+    liftF[KVNamespacedOp, Option[V]](
+      Get[N, K, V](namespace, key)
+    )
+
+  /** Delete a value by key. */
+  def delete(key: K): KVStore[N, Unit] =
+    liftF[KVNamespacedOp, Unit](
+      Delete[N, K](namespace, key)
+    )
+
+  /** Update a key by getting the value and applying a function on it, if the value exists. */
+  def update(key: K, f: V => V): KVStore[N, Unit] =
+    get(key).flatMap {
+      case None    => Free.pure[KVNamespacedOp, Unit](())
+      case Some(v) => put(key, f(v))
+    }
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
@@ -9,7 +9,18 @@ import scodec.Codec
   */
 class KVCollection[N, K: Codec, V: Codec](namespace: N) {
 
-  private implicit val kvs = KVStore.instance[N]
+  private implicit val kvsRW = KVStore.instance[N]
+  private implicit val kvsRO = KVStoreRead.instance[N]
+
+  class ReadOnly {
+
+    /** Get a value by key, if it exists. */
+    def get(key: K): KVStoreRead[N, Option[V]] =
+      KVStoreRead[N].get(namespace, key)
+  }
+
+  /** Project a read-only interface. */
+  val readonly = new ReadOnly
 
   /** Put a value under a key. */
   def put(key: K, value: V): KVStore[N, Unit] =

--- a/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
@@ -12,21 +12,18 @@ class KVCollection[N, K: Codec, V: Codec](namespace: N) {
   private implicit val kvsRW = KVStore.instance[N]
   private implicit val kvsRO = KVStoreRead.instance[N]
 
-  class ReadOnly {
-
-    /** Get a value by key, if it exists. */
-    def get(key: K): KVStoreRead[N, Option[V]] =
-      KVStoreRead[N].get(namespace, key)
-  }
-
-  /** Project a read-only interface. */
-  val readonly = new ReadOnly
+  /** Get a value by key, if it exists, for a read-only operation. */
+  def read(key: K): KVStoreRead[N, Option[V]] =
+    KVStoreRead[N].read(namespace, key)
 
   /** Put a value under a key. */
   def put(key: K, value: V): KVStore[N, Unit] =
     KVStore[N].put(namespace, key, value)
 
-  /** Get a value by key, if it exists. */
+  /** Get a value by key, if it exists, for potentially doing
+    * updates based on its value, i.e. the result can be composed
+    * with `put` and `delete`.
+    */
   def get(key: K): KVStore[N, Option[V]] =
     KVStore[N].get(namespace, key)
 

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
@@ -1,0 +1,32 @@
+package io.iohk.metronome.storage
+
+import scodec.Codec
+
+/** Representing key-value storage operations as a Free Monad,
+  * so that we can pick an execution strategy that best fits
+  * the database technology at hand:
+  * - execute multiple writes atomically by batching
+  * - execute all reads and writes in a transaction
+  *
+  * The key-value store is expected to store binary data,
+  * so a scodec.Codec is required for all operations to
+  * serialize the keys and the values.
+  *
+  * https://typelevel.org/cats/datatypes/freemonad.html
+  */
+sealed trait KVStoreOp[N, A]
+
+object KVStoreOp {
+  case class Put[N, K, V](namespace: N, key: K, value: V)(implicit
+      val ck: Codec[K],
+      val cv: Codec[V]
+  ) extends KVStoreOp[N, Unit]
+
+  case class Get[N, K, V](namespace: N, key: K)(implicit
+      val ck: Codec[K],
+      val cv: Codec[V]
+  ) extends KVStoreOp[N, Option[V]]
+
+  case class Delete[N, K](namespace: N, key: K)(implicit val ck: Codec[K])
+      extends KVStoreOp[N, Unit]
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
@@ -18,15 +18,15 @@ sealed trait KVStoreOp[N, A]
 
 object KVStoreOp {
   case class Put[N, K, V](namespace: N, key: K, value: V)(implicit
-      val ck: Codec[K],
-      val cv: Codec[V]
+      val keyCodec: Codec[K],
+      val valueCodec: Codec[V]
   ) extends KVStoreOp[N, Unit]
 
   case class Get[N, K, V](namespace: N, key: K)(implicit
-      val ck: Codec[K],
-      val cv: Codec[V]
+      val keyCodec: Codec[K],
+      val valueCodec: Codec[V]
   ) extends KVStoreOp[N, Option[V]]
 
-  case class Delete[N, K](namespace: N, key: K)(implicit val ck: Codec[K])
+  case class Delete[N, K](namespace: N, key: K)(implicit val keyCodec: Codec[K])
       extends KVStoreOp[N, Unit]
 }

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
@@ -1,32 +1,60 @@
 package io.iohk.metronome.storage
 
+import cats.free.Free
+import cats.free.Free.liftF
 import scodec.Codec
 
-/** Representing key-value storage operations as a Free Monad,
-  * so that we can pick an execution strategy that best fits
-  * the database technology at hand:
-  * - execute multiple writes atomically by batching
-  * - execute all reads and writes in a transaction
-  *
-  * The key-value store is expected to store binary data,
-  * so a scodec.Codec is required for all operations to
-  * serialize the keys and the values.
-  *
-  * https://typelevel.org/cats/datatypes/freemonad.html
-  */
-sealed trait KVStoreOp[N, A]
+object KVStore {
 
-object KVStoreOp {
-  case class Put[N, K, V](namespace: N, key: K, value: V)(implicit
-      val keyCodec: Codec[K],
-      val valueCodec: Codec[V]
-  ) extends KVStoreOp[N, Unit]
+  def unit[N]: KVStore[N, Unit] =
+    pure(())
 
-  case class Get[N, K, V](namespace: N, key: K)(implicit
-      val keyCodec: Codec[K],
-      val valueCodec: Codec[V]
-  ) extends KVStoreOp[N, Option[V]]
+  def pure[N, A](a: A): KVStore[N, A] =
+    Free.pure(a)
 
-  case class Delete[N, K](namespace: N, key: K)(implicit val keyCodec: Codec[K])
-      extends KVStoreOp[N, Unit]
+  def instance[N]: Ops[N] = new Ops[N] {}
+
+  def apply[N: Ops] = implicitly[Ops[N]]
+
+  /** Scope all operations under the `N` type, which can be more convenient,
+    * e.g. `KVStore[String].pure(1)` instead of `KVStore.pure[String, Int](1)`
+    */
+  trait Ops[N] {
+    import KVStoreOp._
+
+    type KVNamespacedOp[A] = ({ type L[A] = KVStoreOp[N, A] })#L[A]
+
+    def unit: KVStore[N, Unit] = KVStore.unit[N]
+
+    def pure[A](a: A) = KVStore.pure[N, A](a)
+
+    def put[K: Codec, V: Codec](
+        namespace: N,
+        key: K,
+        value: V
+    ): KVStore[N, Unit] =
+      liftF[KVNamespacedOp, Unit](
+        Put[N, K, V](namespace, key, value)
+      )
+
+    def get[K: Codec, V: Codec](namespace: N, key: K): KVStore[N, Option[V]] =
+      liftF[KVNamespacedOp, Option[V]](
+        Get[N, K, V](namespace, key)
+      )
+
+    def delete[K: Codec](namespace: N, key: K): KVStore[N, Unit] =
+      liftF[KVNamespacedOp, Unit](
+        Delete[N, K](namespace, key)
+      )
+
+    def update[K: Codec, V: Codec](
+        namespace: N,
+        key: K,
+        f: V => V
+    ): KVStore[N, Unit] =
+      get[K, V](namespace, key).flatMap {
+        case None        => unit
+        case Some(value) => put(namespace, key, f(value))
+      }
+  }
 }

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreOp.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreOp.scala
@@ -1,0 +1,32 @@
+package io.iohk.metronome.storage
+
+import scodec.Codec
+
+/** Representing key-value storage operations as a Free Monad,
+  * so that we can pick an execution strategy that best fits
+  * the database technology at hand:
+  * - execute multiple writes atomically by batching
+  * - execute all reads and writes in a transaction
+  *
+  * The key-value store is expected to store binary data,
+  * so a scodec.Codec is required for all operations to
+  * serialize the keys and the values.
+  *
+  * https://typelevel.org/cats/datatypes/freemonad.html
+  */
+sealed trait KVStoreOp[N, A]
+
+object KVStoreOp {
+  case class Put[N, K, V](namespace: N, key: K, value: V)(implicit
+      val keyCodec: Codec[K],
+      val valueCodec: Codec[V]
+  ) extends KVStoreOp[N, Unit]
+
+  case class Get[N, K, V](namespace: N, key: K)(implicit
+      val keyCodec: Codec[K],
+      val valueCodec: Codec[V]
+  ) extends KVStoreOp[N, Option[V]]
+
+  case class Delete[N, K](namespace: N, key: K)(implicit val keyCodec: Codec[K])
+      extends KVStoreOp[N, Unit]
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreOp.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreOp.scala
@@ -15,18 +15,20 @@ import scodec.Codec
   * https://typelevel.org/cats/datatypes/freemonad.html
   */
 sealed trait KVStoreOp[N, A]
+sealed trait KVStoreReadOp[N, A]  extends KVStoreOp[N, A]
+sealed trait KVStoreWriteOp[N, A] extends KVStoreOp[N, A]
 
 object KVStoreOp {
   case class Put[N, K, V](namespace: N, key: K, value: V)(implicit
       val keyCodec: Codec[K],
       val valueCodec: Codec[V]
-  ) extends KVStoreOp[N, Unit]
+  ) extends KVStoreWriteOp[N, Unit]
 
   case class Get[N, K, V](namespace: N, key: K)(implicit
       val keyCodec: Codec[K],
       val valueCodec: Codec[V]
-  ) extends KVStoreOp[N, Option[V]]
+  ) extends KVStoreReadOp[N, Option[V]]
 
   case class Delete[N, K](namespace: N, key: K)(implicit val keyCodec: Codec[K])
-      extends KVStoreOp[N, Unit]
+      extends KVStoreWriteOp[N, Unit]
 }

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreRead.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreRead.scala
@@ -1,0 +1,40 @@
+package io.iohk.metronome.storage
+
+import cats.free.Free
+import cats.free.Free.liftF
+import scodec.Codec
+
+/** Helper methods to compose operations that strictly only do reads, no writes.
+  *
+  * Basically the same as `KVStore` without `put` and `delete`.
+  */
+object KVStoreRead {
+
+  def unit[N]: KVStore[N, Unit] =
+    pure(())
+
+  def pure[N, A](a: A): KVStore[N, A] =
+    Free.pure(a)
+
+  def instance[N]: Ops[N] = new Ops[N] {}
+
+  def apply[N: Ops] = implicitly[Ops[N]]
+
+  trait Ops[N] {
+    import KVStoreOp._
+
+    type KVNamespacedOp[A] = ({ type L[A] = KVStoreReadOp[N, A] })#L[A]
+
+    def unit: KVStore[N, Unit] = KVStore.unit[N]
+
+    def pure[A](a: A) = KVStore.pure[N, A](a)
+
+    def get[K: Codec, V: Codec](
+        namespace: N,
+        key: K
+    ): KVStoreRead[N, Option[V]] =
+      liftF[KVNamespacedOp, Option[V]](
+        Get[N, K, V](namespace, key)
+      )
+  }
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreRead.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreRead.scala
@@ -29,7 +29,7 @@ object KVStoreRead {
 
     def pure[A](a: A) = KVStore.pure[N, A](a)
 
-    def get[K: Codec, V: Codec](
+    def read[K: Codec, V: Codec](
         namespace: N,
         key: K
     ): KVStoreRead[N, Option[V]] =

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreState.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreState.scala
@@ -1,10 +1,8 @@
 package io.iohk.metronome.storage
 
-import cats.data.State
 import cats.{~>}
-import io.iohk.metronome.storage.KVStoreOp.Put
-import io.iohk.metronome.storage.KVStoreOp.Get
-import io.iohk.metronome.storage.KVStoreOp.Delete
+import cats.data.State
+import io.iohk.metronome.storage.KVStoreOp.{Put, Get, Delete}
 
 /** A pure implementation of the Free interpreter using the State monad.
   *
@@ -36,7 +34,10 @@ class KVStoreState[N] {
                 // `KVCollection` which works with 1 kind of value;
                 // otherwise we could change the effect to allow errors:
                 // `State[Store, Either[Throwable, A]]`
-              } yield v.asInstanceOf[A]
+
+                // The following cast would work but it's not required:
+                // .asInstanceOf[A]
+              } yield v
             }
 
           case Delete(n, k) =>
@@ -49,7 +50,7 @@ class KVStoreState[N] {
 
   /** Compile a KVStore program to a State monad, which can be executed like:
     *
-    * `new InMemoryKVState[String].compile(program).run(Map.empty).value`
+    * `new KvStoreState[String].compile(program).run(Map.empty).value`
     */
   def compile[A](program: KVStore[N, A]): KVNamespacedState[A] =
     program.foldMap(stateCompiler)

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreState.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreState.scala
@@ -11,7 +11,9 @@ import io.iohk.metronome.storage.KVStoreOp.{Put, Get, Delete}
 class KVStoreState[N] {
 
   // Ignoring the Codec for the in-memory use case.
-  type Store                = Map[N, Map[Any, Any]]
+  type Store = Map[N, Map[Any, Any]]
+  // Type aliases to support the `~>` transformation with types that
+  // only have 1 generic type argument `A`.
   type KVNamespacedState[A] = State[Store, A]
   type KVNamespacedOp[A]    = ({ type L[A] = KVStoreOp[N, A] })#L[A]
 

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreState.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreState.scala
@@ -1,0 +1,56 @@
+package io.iohk.metronome.storage
+
+import cats.data.State
+import cats.{~>}
+import io.iohk.metronome.storage.KVStoreOp.Put
+import io.iohk.metronome.storage.KVStoreOp.Get
+import io.iohk.metronome.storage.KVStoreOp.Delete
+
+/** A pure implementation of the Free interpreter using the State monad.
+  *
+  * It uses a specific namespace type, which is common to all collections.
+  */
+class KVStoreState[N] {
+
+  // Ignoring the Codec for the in-memory use case.
+  type Store                = Map[N, Map[Any, Any]]
+  type KVNamespacedState[A] = State[Store, A]
+  type KVNamespacedOp[A]    = ({ type L[A] = KVStoreOp[N, A] })#L[A]
+
+  private val stateCompiler: KVNamespacedOp ~> KVNamespacedState =
+    new (KVNamespacedOp ~> KVNamespacedState) {
+      def apply[A](fa: KVNamespacedOp[A]): KVNamespacedState[A] =
+        fa match {
+          case Put(n, k, v) =>
+            State.modify { nkvs =>
+              val kvs = nkvs.getOrElse(n, Map.empty)
+              nkvs.updated(n, kvs.updated(k, v))
+            }
+
+          case Get(n, k) =>
+            State.inspect { nkvs =>
+              for {
+                kvs <- nkvs.get(n)
+                v   <- kvs.get(k)
+                // NOTE: This should be fine as long as we access it through
+                // `KVCollection` which works with 1 kind of value;
+                // otherwise we could change the effect to allow errors:
+                // `State[Store, Either[Throwable, A]]`
+              } yield v.asInstanceOf[A]
+            }
+
+          case Delete(n, k) =>
+            State.modify { nkvs =>
+              val kvs = nkvs.getOrElse(n, Map.empty) - k
+              if (kvs.isEmpty) nkvs - n else nkvs.updated(n, kvs)
+            }
+        }
+    }
+
+  /** Compile a KVStore program to a State monad, which can be executed like:
+    *
+    * `new InMemoryKVState[String].compile(program).run(Map.empty).value`
+    */
+  def compile[A](program: KVStore[N, A]): KVNamespacedState[A] =
+    program.foldMap(stateCompiler)
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/package.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/package.scala
@@ -1,0 +1,8 @@
+package io.iohk.metronome
+
+import cats.free.Free
+import cats.data.State
+
+package object storage {
+  type KVStore[N, A] = Free[({ type L[A] = KVStoreOp[N, A] })#L, A]
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/package.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/package.scala
@@ -3,5 +3,10 @@ package io.iohk.metronome
 import cats.free.Free
 
 package object storage {
+
+  /** Read/Write operations over a key-value store. */
   type KVStore[N, A] = Free[({ type L[A] = KVStoreOp[N, A] })#L, A]
+
+  /** Read-only operations over a key-value store. */
+  type KVStoreRead[N, A] = Free[({ type L[A] = KVStoreReadOp[N, A] })#L, A]
 }

--- a/metronome/storage/src/io/iohk/metronome/storage/package.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/package.scala
@@ -9,4 +9,10 @@ package object storage {
 
   /** Read-only operations over a key-value store. */
   type KVStoreRead[N, A] = Free[({ type L[A] = KVStoreReadOp[N, A] })#L, A]
+
+  /** Extension method to lift a read-only operation to read-write. */
+  implicit class KVStoreReadOps[N, A](val read: KVStoreRead[N, A])
+      extends AnyVal {
+    def lift: KVStore[N, A] = KVStore.instance[N].lift(read)
+  }
 }

--- a/metronome/storage/src/io/iohk/metronome/storage/package.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/package.scala
@@ -1,7 +1,6 @@
 package io.iohk.metronome
 
 import cats.free.Free
-import cats.data.State
 
 package object storage {
   type KVStore[N, A] = Free[({ type L[A] = KVStoreOp[N, A] })#L, A]

--- a/metronome/storage/test/src/io/iohk/metronome/storage/KVStoreStateSpec.scala
+++ b/metronome/storage/test/src/io/iohk/metronome/storage/KVStoreStateSpec.scala
@@ -15,13 +15,15 @@ class KVStoreStateSpec extends AnyFlatSpec with Matchers {
     val collA = new KVCollection[Namespace, Int, RecordA](namespace = "a")
     val collB = new KVCollection[Namespace, String, RecordB](namespace = "b")
 
-    val program = for {
+    val program: KVStore[Namespace, Option[RecordA]] = for {
       _ <- collA.put(1, RecordA("one"))
       _ <- collB.put("two", RecordB(2))
-      _ <- collB.get("three")
+      b <- collB.get("three")
       _ <- collB.put("three", RecordB(3))
       _ <- collB.delete("two")
-      _ <- collA.put(4, RecordA("four"))
+      _ <-
+        if (b.isEmpty) collA.put(4, RecordA("four"))
+        else KVStore.unit[Namespace]
       a <- collA.get(1)
     } yield a
 

--- a/metronome/storage/test/src/io/iohk/metronome/storage/KVStoreStateSpec.scala
+++ b/metronome/storage/test/src/io/iohk/metronome/storage/KVStoreStateSpec.scala
@@ -24,7 +24,7 @@ class KVStoreStateSpec extends AnyFlatSpec with Matchers {
       _ <-
         if (b.isEmpty) collA.put(4, RecordA("four"))
         else KVStore.unit[Namespace]
-      a <- collA.get(1)
+      a <- collA.read(1).lift
     } yield a
 
     val compiler = new KVStoreState[Namespace]

--- a/metronome/storage/test/src/io/iohk/metronome/storage/KVStoreStateSpec.scala
+++ b/metronome/storage/test/src/io/iohk/metronome/storage/KVStoreStateSpec.scala
@@ -1,0 +1,44 @@
+package io.iohk.metronome.storage
+
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scodec.codecs.implicits._
+
+class KVStoreStateSpec extends AnyFlatSpec with Matchers {
+  import KVStoreStateSpec._
+
+  behavior of "KVStoreState"
+
+  it should "compose multiple collections" in {
+    type Namespace = String
+    // Two independent collections with different types of keys and values.
+    val collA = new KVCollection[Namespace, Int, RecordA](namespace = "a")
+    val collB = new KVCollection[Namespace, String, RecordB](namespace = "b")
+
+    val program = for {
+      _ <- collA.put(1, RecordA("one"))
+      _ <- collB.put("two", RecordB(2))
+      _ <- collB.get("three")
+      _ <- collB.put("three", RecordB(3))
+      _ <- collB.delete("two")
+      _ <- collA.put(4, RecordA("four"))
+      a <- collA.get(1)
+    } yield a
+
+    val compiler = new KVStoreState[Namespace]
+
+    val (store, maybeA) = compiler.compile(program).run(Map.empty).value
+
+    maybeA shouldBe Some(RecordA("one"))
+    store shouldBe Map(
+      "a" -> Map(1 -> RecordA("one"), 4 -> RecordA("four")),
+      "b" -> Map("three" -> RecordB(3))
+    )
+  }
+}
+
+object KVStoreStateSpec {
+  case class RecordA(a: String)
+  case class RecordB(b: Int)
+}

--- a/metronome/storage/test/src/io/iohk/metronome/storage/KVStoreStateSpec.scala
+++ b/metronome/storage/test/src/io/iohk/metronome/storage/KVStoreStateSpec.scala
@@ -1,6 +1,5 @@
 package io.iohk.metronome.storage
 
-import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scodec.codecs.implicits._


### PR DESCRIPTION
Adds a `KVStore` abstraction using a `Free` monad so that we can execute queries/writes against multiple data stores in one batch, including in a transaction if we upgrade to the next version of RocksDB.

Includes an in-memory implementation as well, against which the RocksDB one is tested.

Check out `KVStoreStateSpec` for to have an idea how this could be used. Each domain object is in a separate collection like we have them in Mantis (e.g. `BlockStore`, `BlockHeaderStore`, `AppStateStore`), each with its own key and value type. 

The idea is that normal code would compose queries such as this:

```scala
val query: KVStore[Namespace, Boolean] = for {
  bestBlockNumber <- AppStateStore.getBestBlockNumber
  bestBlockHash <- BlockNumberMapping.get(bestBlockNumber)
  nextBlockNumber = nextBlock.header.number
  ok = nextBlock.parentHash == bestBlockHash && nextBlockNumber == bestBlockNumber + 1
  _ <- if (ok) {
    BlockHeaderStore.put(nextBlock.hash, nextBlock.header) >>
    BlockBodyStore.put(nextBlock.hash, nextBlock.body) >>
    BlockNumberMapping.put(nextBlockNumber, nextBlock.hash) >>
    AppStorage.putBestBlockNumber(nextBlockNumber) 
 } else KVStore.unit[Namespace]
} yield ok
```

That would not execute anything, rather, the class that created the `query` would need to have some dependency that knows how to deal with it. The programmer would know in this case that this does writes, so they'd execute it like this:

```scala
val inserted: Task[Boolean] = db.runWithBatching(query)
```

The database uses read-write locks to make sure multiple reads can be performed without having writes interfere. But if we had a version of RocksDB that supports transactions, we can replace the call above with `db.runInTransaction(query)` as well, without having to touch any parts of the program except the top level interpreter.
