### PR TITLE
PM-3093: Add publish script.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,13 @@ jobs:
                 # GPG in docker needs to be run with some additional flags
                 # and we are not able to change how mill uses it
                 # this is why we're creating wrapper that adds the flags
-                command: sh -c "apt update && apt install -y gnupg2 && mv /usr/bin/gpg /usr/bin/gpg-vanilla && echo '#!/bin/sh\n\n/usr/bin/gpg-vanilla --no-tty --pinentry loopback \$@' > /usr/bin/gpg && chmod 755 /usr/bin/gpg && cat /usr/bin/gpg"
+                command: |
+                  sudo apt update
+                  sudo apt install -y gnupg2
+                  sudo mv /usr/bin/gpg /usr/bin/gpg-vanilla
+                  sudo sh -c "echo '#!/bin/sh\n\n/usr/bin/gpg-vanilla --no-tty --pinentry loopback \$@' > /usr/bin/gpg"
+                  sudo chmod 755 /usr/bin/gpg
+                  cat /usr/bin/gpg
 
             - run:
                 name: install base64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
             or:
               - equal: [ master, << pipeline.git.branch >> ]
               - equal: [ develop, << pipeline.git.branch >> ]
-              - equal: [ PM-3093-publish, << pipeline.git.branch >> ]
           steps:
             - run:
                 name: install gpg2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: openjdk:11
+      - image: circleci/openjdk:11-jdk
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
 
             - run:
                 name: install base64
-                command: apt update && apt install -y cl-base64
+                command: sudo apt update && sudo apt install -y cl-base64
 
             - run:
                 name: publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: openjdk:11
 
     working_directory: ~/repo
 
@@ -61,6 +61,7 @@ jobs:
             or:
               - equal: [ master, << pipeline.git.branch >> ]
               - equal: [ develop, << pipeline.git.branch >> ]
+              - equal: [ PM-3093-publish, << pipeline.git.branch >> ]
           steps:
             - run:
                 name: install gpg2
@@ -73,11 +74,10 @@ jobs:
                 name: install base64
                 command: apt update && apt install -y cl-base64
 
-            # TODO: Configure Mantis' credentials
-            # - run:
-            #     name: publish
-            #     command: .circleci/publish
-            #     no_output_timeout: 30m
+            - run:
+                name: publish
+                command: .circleci/publish
+                no_output_timeout: 30m
 
 workflows:
   build_and_publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
 
             - run:
                 name: publish
-                command: .circleci/publish
+                command: .circleci/publish.sh
                 no_output_timeout: 30m
 
 workflows:

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -6,7 +6,7 @@ echo $GPG_KEY | base64 --decode | gpg --batch --import
 
 gpg --passphrase $GPG_PASSPHRASE --batch --yes -a -b LICENSE
 
-if [[ "$CIRCLE_BRANCH" == "develop" || "$CIRCLE_BRANCH" == "PM-3093-publish" ]]; then
+if [[ "$CIRCLE_BRANCH" == "develop" ]]; then
 
 mill mill.scalalib.PublishModule/publishAll \
     __.publishArtifacts \

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euv
+
+echo $GPG_KEY | base64 --decode | gpg --batch --import
+
+gpg --passphrase $GPG_PASSPHRASE --batch --yes -a -b LICENSE
+
+if [[ "$CIRCLE_BRANCH" == "develop" || "$CIRCLE_BRANCH" == "PM-3093-publish" ]]; then
+
+mill mill.scalalib.PublishModule/publishAll \
+    __.publishArtifacts \
+    "$OSS_USERNAME":"$OSS_PASSWORD" \
+    --gpgArgs --passphrase="$GPG_PASSPHRASE",--batch,--yes,-a,-b
+
+elif [[ "$CIRCLE_BRANCH" == "master" ]]; then
+
+mill versionFile.setReleaseVersion
+mill mill.scalalib.PublishModule/publishAll \
+    __.publishArtifacts \
+    "$OSS_USERNAME":"$OSS_PASSWORD" \
+    --gpgArgs --passphrase="$GPG_PASSPHRASE",--batch,--yes,-a,-b \
+    --readTimeout 600000 \
+    --awaitTimeout 600000 \
+    --release true
+
+else
+
+  echo "Skipping publish step"
+
+fi


### PR DESCRIPTION
Copied the publish script from Scalanet. Using `sudo` because we're using the `circleci` version of the JDK docker image. The one that isn't from `circleci` would have no support for `BASH_ENV` so the way Coursier is installed wouldn't work any more.