### PR TITLE
PM-2907: Emit trace events from networking.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -21,10 +21,10 @@ object VersionOf {
   val prometheus       = "0.10.0"
   val rocksdb          = "6.15.2"
   val scalacheck       = "1.15.2"
-  val scalalogging     = "3.9.2"
   val scalatest        = "3.2.5"
   val scalanet         = "0.7.0"
   val shapeless        = "2.3.3"
+  val slf4j            = "1.7.30"
   val `scodec-core`    = "1.11.7"
   val `scodec-bits`    = "1.1.12"
 }
@@ -129,6 +129,9 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       override def moduleDeps: Seq[JavaModule] =
         super.moduleDeps ++ Seq(logging)
 
+      // Enable logging in tests.
+      // Control the visibility using ./test/resources/logback.xml
+      // Alternatively, capture logs in memory.
       override def ivyDeps = Agg(
         ivy"org.scalatest::scalatest:${VersionOf.scalatest}",
         ivy"org.scalacheck::scalacheck:${VersionOf.scalacheck}",
@@ -296,13 +299,17 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
     }
   }
 
-  /** Implements tracing abstractions to do structured logging. */
+  /** Implements tracing abstractions to do structured logging.
+    *
+    * To actually emit logs, a dependant module also has to add
+    * a dependency on e.g. logback.
+    */
   object logging extends SubModule {
     override def moduleDeps: Seq[JavaModule] =
       Seq(tracing)
 
     override def ivyDeps = super.ivyDeps() ++ Agg(
-      ivy"com.typesafe.scala-logging::scala-logging:${VersionOf.scalalogging}",
+      ivy"org.slf4j:slf4j-api:${VersionOf.slf4j}",
       ivy"io.circe::circe-core:${VersionOf.circe}"
     )
   }

--- a/build.sc
+++ b/build.sc
@@ -12,6 +12,7 @@ object versionFile extends VersionFileModule
 
 object VersionOf {
   val cats             = "2.3.1"
+  val circe            = "0.12.3"
   val config           = "1.4.1"
   val `kind-projector` = "0.11.3"
   val logback          = "1.2.3"
@@ -201,7 +202,10 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       ivy"io.iohk::scalanet:${VersionOf.scalanet}"
     )
 
-    object test extends TestModule
+    object test extends TestModule {
+      override def moduleDeps: Seq[JavaModule] =
+        super.moduleDeps ++ Seq(logging)
+    }
   }
 
   /** Generic HotStuff BFT library. */
@@ -298,7 +302,8 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       Seq(tracing)
 
     override def ivyDeps = super.ivyDeps() ++ Agg(
-      ivy"com.typesafe.scala-logging::scala-logging:${VersionOf.scalalogging}"
+      ivy"com.typesafe.scala-logging::scala-logging:${VersionOf.scalalogging}",
+      ivy"io.circe::circe-core:${VersionOf.circe}"
     )
   }
 

--- a/metronome/logging/src/io/iohk/metronome/logging/HybridLog.scala
+++ b/metronome/logging/src/io/iohk/metronome/logging/HybridLog.scala
@@ -1,0 +1,33 @@
+package io.iohk.metronome.logging
+
+import io.circe.JsonObject
+import java.time.Instant
+import scala.reflect.ClassTag
+
+trait HybridLog[T] {
+  def apply(value: T): HybridLogObject
+}
+
+object HybridLog {
+  def apply[T](implicit ev: HybridLog[T]): HybridLog[T] = ev
+
+  def instance[T: ClassTag](
+      level: T => HybridLogObject.Level,
+      message: T => String,
+      event: T => JsonObject,
+      source: Option[String] = None
+  ): HybridLog[T] =
+    new HybridLog[T] {
+      val className = implicitly[ClassTag[T]].runtimeClass.getName
+
+      override def apply(value: T): HybridLogObject = {
+        HybridLogObject(
+          level = level(value),
+          timestamp = Instant.now(),
+          source = source getOrElse className,
+          message = message(value),
+          event = event(value)
+        )
+      }
+    }
+}

--- a/metronome/logging/src/io/iohk/metronome/logging/HybridLog.scala
+++ b/metronome/logging/src/io/iohk/metronome/logging/HybridLog.scala
@@ -4,6 +4,7 @@ import io.circe.JsonObject
 import java.time.Instant
 import scala.reflect.ClassTag
 
+/** Type class to transform instances of `T` to `HybridLogObject`. */
 trait HybridLog[T] {
   def apply(value: T): HybridLogObject
 }
@@ -11,20 +12,22 @@ trait HybridLog[T] {
 object HybridLog {
   def apply[T](implicit ev: HybridLog[T]): HybridLog[T] = ev
 
+  /** Create an instance of `HybridLog` for a type `T` by passing
+    * functions to transform instances of `T` to message and JSON.
+    */
   def instance[T: ClassTag](
       level: T => HybridLogObject.Level,
       message: T => String,
-      event: T => JsonObject,
-      source: Option[String] = None
+      event: T => JsonObject
   ): HybridLog[T] =
     new HybridLog[T] {
-      val className = implicitly[ClassTag[T]].runtimeClass.getName
+      val source = implicitly[ClassTag[T]].runtimeClass.getName
 
       override def apply(value: T): HybridLogObject = {
         HybridLogObject(
           level = level(value),
           timestamp = Instant.now(),
-          source = source getOrElse className,
+          source = source,
           message = message(value),
           event = event(value)
         )

--- a/metronome/logging/src/io/iohk/metronome/logging/HybridLogObject.scala
+++ b/metronome/logging/src/io/iohk/metronome/logging/HybridLogObject.scala
@@ -3,7 +3,6 @@ package io.iohk.metronome.logging
 import io.circe.JsonObject
 import io.circe.syntax._
 import java.time.Instant
-import scala.reflect.ClassTag
 import cats.Show
 
 /** A hybrid log has a human readable message, which is intended to be static,

--- a/metronome/logging/src/io/iohk/metronome/logging/HybridLogObject.scala
+++ b/metronome/logging/src/io/iohk/metronome/logging/HybridLogObject.scala
@@ -29,6 +29,7 @@ object HybridLogObject {
     case object Warn  extends Level
     case object Info  extends Level
     case object Debug extends Level
+    case object Trace extends Level
   }
 
   implicit val show: Show[HybridLogObject] = Show.show {

--- a/metronome/logging/src/io/iohk/metronome/logging/HybridLogObject.scala
+++ b/metronome/logging/src/io/iohk/metronome/logging/HybridLogObject.scala
@@ -1,0 +1,38 @@
+package io.iohk.metronome.logging
+
+import io.circe.JsonObject
+import io.circe.syntax._
+import java.time.Instant
+import scala.reflect.ClassTag
+import cats.Show
+
+/** A hybrid log has a human readable message, which is intended to be static,
+  * and some key-value paramters that vary by events.
+  *
+  * See https://medium.com/unomaly/logging-wisdom-how-to-log-5a19145e35ec
+  */
+case class HybridLogObject(
+    timestamp: Instant,
+    source: String,
+    level: HybridLogObject.Level,
+    // Something captured about what emitted this event.
+    // Human readable message, which typically shouldn't
+    // change between events emitted at the same place.
+    message: String,
+    // Key-Value pairs that capture arbitrary data.
+    event: JsonObject
+)
+object HybridLogObject {
+  sealed trait Level
+  object Level {
+    case object Error extends Level
+    case object Warn  extends Level
+    case object Info  extends Level
+    case object Debug extends Level
+  }
+
+  implicit val show: Show[HybridLogObject] = Show.show {
+    case HybridLogObject(t, s, l, m, e) =>
+      s"$t ${l.toString.toUpperCase.padTo(5, ' ')} - $s: $m ${e.asJson.noSpaces}"
+  }
+}

--- a/metronome/logging/src/io/iohk/metronome/logging/InMemoryLogTracer.scala
+++ b/metronome/logging/src/io/iohk/metronome/logging/InMemoryLogTracer.scala
@@ -1,0 +1,50 @@
+package io.iohk.metronome.logging
+
+import cats.implicits._
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import io.iohk.metronome.tracer.Tracer
+
+/** Collect logs in memory, so we can inspect them in tests. */
+object InMemoryLogTracer {
+
+  class HybridLogTracer[F[_]: Sync](
+      logRef: Ref[F, Vector[HybridLogObject]]
+  ) extends Tracer[F, HybridLogObject] {
+
+    override def apply(a: => HybridLogObject): F[Unit] =
+      logRef.update(_ :+ a)
+
+    def getLogs: F[Seq[HybridLogObject]] =
+      logRef.get.map(_.toSeq)
+
+    def getLevel(l: HybridLogObject.Level) =
+      getLogs.map(_.filter(_.level == l))
+
+    def getErrors = getLevel(HybridLogObject.Level.Error)
+    def getWarns  = getLevel(HybridLogObject.Level.Warn)
+    def getInfos  = getLevel(HybridLogObject.Level.Info)
+    def getDebugs = getLevel(HybridLogObject.Level.Debug)
+    def getTraces = getLevel(HybridLogObject.Level.Trace)
+  }
+
+  /** For example:
+    *
+    * ```
+    * val logTracer = InMemoryLogTracer.hybrid[Task]
+    * val networkEventTracer   = logTracer.contramap(implicitly[HybridLog[NetworkEvent]].apply _)
+    * val consensusEventTracer = logTracer.contramap(implicitly[HybridLog[ConsensusEvent]].apply _)
+    *
+    * val test = for {
+    *   msg   <- network.nextMessage
+    *   _     <- consensus.handleMessage(msg)
+    *   warns <- logTracer.getWarns
+    * } yield {
+    *   warns shouldBe empty
+    * }
+    *
+    * ```
+    */
+  def hybrid[F[_]: Sync]: Tracer[F, HybridLogObject] =
+    new HybridLogTracer[F](Ref.unsafe[F, Vector[HybridLogObject]](Vector.empty))
+}

--- a/metronome/logging/src/io/iohk/metronome/logging/LogTracer.scala
+++ b/metronome/logging/src/io/iohk/metronome/logging/LogTracer.scala
@@ -1,0 +1,1 @@
+// package io.iohk.metronome.logging

--- a/metronome/logging/src/io/iohk/metronome/logging/LogTracer.scala
+++ b/metronome/logging/src/io/iohk/metronome/logging/LogTracer.scala
@@ -1,1 +1,38 @@
-// package io.iohk.metronome.logging
+package io.iohk.metronome.logging
+
+import cats.syntax.contravariant._
+import cats.effect.Sync
+import io.circe.syntax._
+import io.iohk.metronome.tracer.Tracer
+import org.slf4j.LoggerFactory
+
+/** Forward traces to SLF4J logs. */
+object LogTracer {
+
+  /** Create a logger for `HybridLogObject` that delegates to SLF4J. */
+  def hybrid[F[_]: Sync]: Tracer[F, HybridLogObject] =
+    new Tracer[F, HybridLogObject] {
+      override def apply(log: => HybridLogObject): F[Unit] = Sync[F].delay {
+        val logger = LoggerFactory.getLogger(log.source)
+
+        def message = s"${log.message} ${log.event.asJson.noSpaces}"
+
+        log.level match {
+          case HybridLogObject.Level.Error =>
+            if (logger.isErrorEnabled) logger.error(message)
+          case HybridLogObject.Level.Warn =>
+            if (logger.isWarnEnabled) logger.warn(message)
+          case HybridLogObject.Level.Info =>
+            if (logger.isInfoEnabled) logger.info(message)
+          case HybridLogObject.Level.Debug =>
+            if (logger.isDebugEnabled) logger.debug(message)
+          case HybridLogObject.Level.Trace =>
+            if (logger.isTraceEnabled) logger.trace(message)
+        }
+      }
+    }
+
+  /** Create a logger for a type that can be transformed to a `HybridLogObject`. */
+  def hybrid[F[_]: Sync, T: HybridLog]: Tracer[F, T] =
+    hybrid[F].contramap(implicitly[HybridLog[T]].apply _)
+}

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
@@ -1,0 +1,28 @@
+package io.iohk.metronome.networking
+
+import java.net.InetSocketAddress
+
+/** Events we want to trace. */
+sealed trait NetworkEvent[K]
+
+object NetworkEvent {
+  case class ConnectionRegistered[K](
+      key: K,
+      serverAddress: InetSocketAddress
+  ) extends NetworkEvent[K]
+
+  case class ConnectionDeregistered[K](
+      key: K,
+      serverAddress: InetSocketAddress
+  ) extends NetworkEvent[K]
+
+  case class ConnectionDiscarded[K](
+      key: K,
+      serverAddress: InetSocketAddress
+  ) extends NetworkEvent[K]
+
+  case class ConnectionFailed[K](
+      failure: RemoteConnectionManager.ConnectionFailure[K]
+  ) extends NetworkEvent[K]
+
+}

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
@@ -6,23 +6,29 @@ import java.net.InetSocketAddress
 sealed trait NetworkEvent[K]
 
 object NetworkEvent {
-  case class ConnectionRegistered[K](
-      key: K,
-      address: InetSocketAddress
-  ) extends NetworkEvent[K]
 
-  case class ConnectionDeregistered[K](
-      key: K,
-      address: InetSocketAddress
-  ) extends NetworkEvent[K]
+  case class Peer[K](key: K, address: InetSocketAddress)
 
-  case class ConnectionDiscarded[K](
-      key: K,
-      address: InetSocketAddress
-  ) extends NetworkEvent[K]
+  /** The connection to/from the peer has been added to the register. */
+  case class ConnectionRegistered[K](peer: Peer[K]) extends NetworkEvent[K]
 
+  /** The connection to/from the peer has been closed and removed from the register. */
+  case class ConnectionDeregistered[K](peer: Peer[K]) extends NetworkEvent[K]
+
+  /** We had two connections to/from the peer and discarded one of them. */
+  case class ConnectionDiscarded[K](peer: Peer[K]) extends NetworkEvent[K]
+
+  /** Failed to establish connection to remote peer. */
   case class ConnectionFailed[K](
-      failure: RemoteConnectionManager.ConnectionFailure[K]
+      peer: Peer[K],
+      numberOfFailures: Int,
+      error: Throwable
+  ) extends NetworkEvent[K]
+
+  /** An established connection has experienced an error. */
+  case class ConnectionError[K](
+      peer: Peer[K],
+      error: EncryptedConnectionProvider.ConnectionError
   ) extends NetworkEvent[K]
 
 }

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
@@ -31,4 +31,7 @@ object NetworkEvent {
       error: EncryptedConnectionProvider.ConnectionError
   ) extends NetworkEvent[K]
 
+  /** Incoming connection from someone outside the federation. */
+  case class ConnectionUnknown[K](peer: Peer[K]) extends NetworkEvent[K]
+
 }

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
@@ -8,17 +8,17 @@ sealed trait NetworkEvent[K]
 object NetworkEvent {
   case class ConnectionRegistered[K](
       key: K,
-      serverAddress: InetSocketAddress
+      address: InetSocketAddress
   ) extends NetworkEvent[K]
 
   case class ConnectionDeregistered[K](
       key: K,
-      serverAddress: InetSocketAddress
+      address: InetSocketAddress
   ) extends NetworkEvent[K]
 
   case class ConnectionDiscarded[K](
       key: K,
-      serverAddress: InetSocketAddress
+      address: InetSocketAddress
   ) extends NetworkEvent[K]
 
   case class ConnectionFailed[K](

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
@@ -3,35 +3,52 @@ package io.iohk.metronome.networking
 import java.net.InetSocketAddress
 
 /** Events we want to trace. */
-sealed trait NetworkEvent[K]
+sealed trait NetworkEvent[K, +M]
 
 object NetworkEvent {
 
   case class Peer[K](key: K, address: InetSocketAddress)
 
   /** The connection to/from the peer has been added to the register. */
-  case class ConnectionRegistered[K](peer: Peer[K]) extends NetworkEvent[K]
+  case class ConnectionRegistered[K](peer: Peer[K])
+      extends NetworkEvent[K, Nothing]
 
   /** The connection to/from the peer has been closed and removed from the register. */
-  case class ConnectionDeregistered[K](peer: Peer[K]) extends NetworkEvent[K]
+  case class ConnectionDeregistered[K](peer: Peer[K])
+      extends NetworkEvent[K, Nothing]
 
   /** We had two connections to/from the peer and discarded one of them. */
-  case class ConnectionDiscarded[K](peer: Peer[K]) extends NetworkEvent[K]
+  case class ConnectionDiscarded[K](peer: Peer[K])
+      extends NetworkEvent[K, Nothing]
 
   /** Failed to establish connection to remote peer. */
   case class ConnectionFailed[K](
       peer: Peer[K],
       numberOfFailures: Int,
       error: Throwable
-  ) extends NetworkEvent[K]
+  ) extends NetworkEvent[K, Nothing]
 
-  /** An established connection has experienced an error. */
-  case class ConnectionError[K](
+  /** Error reading data from a connection. */
+  case class ConnectionReceiveError[K](
       peer: Peer[K],
       error: EncryptedConnectionProvider.ConnectionError
-  ) extends NetworkEvent[K]
+  ) extends NetworkEvent[K, Nothing]
+
+  /** Error sending data over a connection, already disconnected. */
+  case class ConnectionSendError[K](
+      peer: Peer[K]
+  ) extends NetworkEvent[K, Nothing]
 
   /** Incoming connection from someone outside the federation. */
-  case class ConnectionUnknown[K](peer: Peer[K]) extends NetworkEvent[K]
+  case class ConnectionUnknown[K](peer: Peer[K])
+      extends NetworkEvent[K, Nothing]
+
+  /** Received incoming message from peer. */
+  case class MessageReceived[K, M](peer: Peer[K], message: M)
+      extends NetworkEvent[K, M]
+
+  /** Sent outgoing message to peer. */
+  case class MessageSent[K, M](peer: Peer[K], message: M)
+      extends NetworkEvent[K, M]
 
 }

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkTracers.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkTracers.scala
@@ -1,0 +1,34 @@
+package io.iohk.metronome.networking
+
+import cats.implicits._
+import io.iohk.tracer.Tracer
+
+case class NetworkTracers[F[_], K, M](
+    registered: Tracer[F, ConnectionHandler.HandledConnection[F, K, M]],
+    deregistered: Tracer[F, ConnectionHandler.HandledConnection[F, K, M]],
+    discarded: Tracer[F, ConnectionHandler.HandledConnection[F, K, M]],
+    failed: Tracer[F, RemoteConnectionManager.ConnectionFailure[K]]
+)
+
+object NetworkTracers {
+  import NetworkEvent._
+  import ConnectionHandler.HandledConnection
+
+  def apply[F[_], K, M](
+      tracer: Tracer[F, NetworkEvent[K]]
+  ): NetworkTracers[F, K, M] =
+    NetworkTracers[F, K, M](
+      registered = tracer.contramap[HandledConnection[F, K, M]] { conn =>
+        ConnectionRegistered(conn.key, conn.serverAddress)
+      },
+      deregistered = tracer.contramap[HandledConnection[F, K, M]] { conn =>
+        ConnectionDeregistered(conn.key, conn.serverAddress)
+      },
+      discarded = tracer.contramap[HandledConnection[F, K, M]] { conn =>
+        ConnectionDiscarded(conn.key, conn.serverAddress)
+      },
+      failed = tracer.contramap[RemoteConnectionManager.ConnectionFailure[K]] {
+        ConnectionFailed(_)
+      }
+    )
+}

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkTracers.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkTracers.scala
@@ -1,7 +1,7 @@
 package io.iohk.metronome.networking
 
 import cats.implicits._
-import io.iohk.tracer.Tracer
+import io.iohk.metronome.tracer.Tracer
 
 case class NetworkTracers[F[_], K, M](
     registered: Tracer[F, ConnectionHandler.HandledConnection[F, K, M]],

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkTracers.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkTracers.scala
@@ -7,28 +7,43 @@ case class NetworkTracers[F[_], K, M](
     registered: Tracer[F, ConnectionHandler.HandledConnection[F, K, M]],
     deregistered: Tracer[F, ConnectionHandler.HandledConnection[F, K, M]],
     discarded: Tracer[F, ConnectionHandler.HandledConnection[F, K, M]],
-    failed: Tracer[F, RemoteConnectionManager.ConnectionFailure[K]]
+    failed: Tracer[F, RemoteConnectionManager.ConnectionFailure[K]],
+    error: Tracer[F, NetworkTracers.HandledConnectionError[F, K, M]]
 )
 
 object NetworkTracers {
   import NetworkEvent._
   import ConnectionHandler.HandledConnection
 
+  type HandledConnectionError[F[_], K, M] = (
+      ConnectionHandler.HandledConnection[F, K, M],
+      EncryptedConnectionProvider.ConnectionError
+  )
+
   def apply[F[_], K, M](
       tracer: Tracer[F, NetworkEvent[K]]
   ): NetworkTracers[F, K, M] =
     NetworkTracers[F, K, M](
       registered = tracer.contramap[HandledConnection[F, K, M]] { conn =>
-        ConnectionRegistered(conn.key, conn.serverAddress)
+        ConnectionRegistered(Peer(conn.key, conn.serverAddress))
       },
       deregistered = tracer.contramap[HandledConnection[F, K, M]] { conn =>
-        ConnectionDeregistered(conn.key, conn.serverAddress)
+        ConnectionDeregistered(Peer(conn.key, conn.serverAddress))
       },
       discarded = tracer.contramap[HandledConnection[F, K, M]] { conn =>
-        ConnectionDiscarded(conn.key, conn.serverAddress)
+        ConnectionDiscarded(Peer(conn.key, conn.serverAddress))
       },
-      failed = tracer.contramap[RemoteConnectionManager.ConnectionFailure[K]] {
-        ConnectionFailed(_)
+      failed =
+        tracer.contramap[RemoteConnectionManager.ConnectionFailure[K]] { fail =>
+          ConnectionFailed(
+            Peer(fail.connectionRequest.key, fail.connectionRequest.address),
+            fail.connectionRequest.numberOfFailures,
+            fail.err
+          )
+        },
+      error = tracer.contramap[HandledConnectionError[F, K, M]] {
+        case (conn, err) =>
+          ConnectionError(Peer(conn.key, conn.serverAddress), err)
       }
     )
 }

--- a/metronome/networking/src/io/iohk/metronome/networking/RemoteConnectionManager.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/RemoteConnectionManager.scala
@@ -204,7 +204,7 @@ object RemoteConnectionManager {
       pg: EncryptedConnectionProvider[F, K, M],
       connectionsHandler: ConnectionHandler[F, K, M],
       clusterConfig: ClusterConfig[K]
-  ): F[Unit] = {
+  )(implicit tracers: NetworkTracers[F, K, M]): F[Unit] = {
     Iterant
       .repeatEvalF(pg.incomingConnection)
       .takeWhile(_.isDefined)
@@ -225,7 +225,8 @@ object RemoteConnectionManager {
 
           case None =>
             // unknown connection, just close it
-            encryptedConnection.close
+            tracers.unknown(encryptedConnection) >>
+              encryptedConnection.close
         }
       }
       .completedL

--- a/metronome/networking/src/io/iohk/metronome/networking/RemoteConnectionManager.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/RemoteConnectionManager.scala
@@ -40,7 +40,7 @@ class RemoteConnectionManager[F[_]: Sync, K, M: Codec](
     connectionHandler.sendMessage(recipient, message)
   }
 }
-//TODO add logging
+
 object RemoteConnectionManager {
   case class ConnectionSuccess[F[_], K, M](
       encryptedConnection: EncryptedConnection[F, K, M]
@@ -170,7 +170,7 @@ object RemoteConnectionManager {
       connectionsToAcquire: ConcurrentQueue[F, OutGoingConnectionRequest[K]],
       connectionsHandler: ConnectionHandler[F, K, M],
       retryConfig: RetryConfig
-  ): F[Unit] = {
+  )(implicit tracers: NetworkTracers[F, K, M]): F[Unit] = {
 
     /** Observable is used here as streaming primitive as it has richer api than Iterant and have mapParallelUnorderedF
       * combinator, which makes it possible to have multiple concurrent retry timers, which are cancelled when whole
@@ -184,11 +184,11 @@ object RemoteConnectionManager {
       }
       .mapParallelUnorderedF(Integer.MAX_VALUE) {
         case Left(failure) =>
-          //TODO add logging of failure
           val failureToLog = failure.err
-          retryConnection(retryConfig, failure.connectionRequest).flatMap(
-            updatedRequest => connectionsToAcquire.offer(updatedRequest)
-          )
+          tracers.failed(failure) >>
+            retryConnection(retryConfig, failure.connectionRequest).flatMap(
+              updatedRequest => connectionsToAcquire.offer(updatedRequest)
+            )
         case Right(connection) =>
           val newOutgoingConnections =
             HandledConnection.outgoing(connection.encryptedConnection)
@@ -308,7 +308,8 @@ object RemoteConnectionManager {
       clusterConfig: ClusterConfig[K],
       retryConfig: RetryConfig
   )(implicit
-      cs: ContextShift[F]
+      cs: ContextShift[F],
+      tracers: NetworkTracers[F, K, M]
   ): Resource[F, RemoteConnectionManager[F, K, M]] = {
     for {
       connectionsToAcquireQueue <- Resource.liftF(
@@ -341,11 +342,13 @@ object RemoteConnectionManager {
         connectionsHandler,
         retryConfig
       ).background
+
       _ <- handleServerConnections(
         encryptedConnectionsProvider,
         connectionsHandler,
         clusterConfig
       ).background
+
     } yield new RemoteConnectionManager[F, K, M](
       connectionsHandler,
       encryptedConnectionsProvider.localPeerInfo

--- a/metronome/networking/test/resources/logback.xml
+++ b/metronome/networking/test/resources/logback.xml
@@ -11,7 +11,7 @@
 
     <logger name="io.iohk.scalanet.peergroup" level="OFF"/>
 
-    <root level="WARN">
+    <root level="ERROR">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/metronome/networking/test/src/io/iohk/metronome/networking/ConnectionHandlerSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/ConnectionHandlerSpec.scala
@@ -24,6 +24,7 @@ import io.iohk.metronome.networking.EncryptedConnectionProvider.DecodingError
 import io.iohk.metronome.networking.RemoteConnectionManagerWithMockProviderSpec.fakeLocalAddress
 
 import java.net.InetSocketAddress
+import io.iohk.tracer.Tracer
 
 class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
   implicit val testScheduler =
@@ -244,6 +245,9 @@ object ConnectionHandlerSpec {
       task.restartUntil(condition).timeout(timeOut)
     }
   }
+
+  implicit val tracers: NetworkTracers[Task, Secp256k1Key, TestMessage] =
+    NetworkTracers(Tracer.noOpTracer)
 
   def buildHandlerResource(
       cb: HandledConnection[Task, Secp256k1Key, TestMessage] => Task[Unit] =

--- a/metronome/networking/test/src/io/iohk/metronome/networking/ConnectionHandlerSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/ConnectionHandlerSpec.scala
@@ -22,9 +22,8 @@ import monix.eval.Task
 import ConnectionHandlerSpec._
 import io.iohk.metronome.networking.EncryptedConnectionProvider.DecodingError
 import io.iohk.metronome.networking.RemoteConnectionManagerWithMockProviderSpec.fakeLocalAddress
-
+import io.iohk.metronome.tracer.Tracer
 import java.net.InetSocketAddress
-import io.iohk.tracer.Tracer
 
 class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
   implicit val testScheduler =

--- a/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithMockProviderSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithMockProviderSpec.scala
@@ -18,6 +18,7 @@ import io.iohk.metronome.networking.RemoteConnectionManagerWithMockProviderSpec.
   fakeLocalAddress,
   longRetryConfig
 }
+import io.iohk.tracer.Tracer
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.flatspec.AsyncFlatSpecLike
@@ -340,6 +341,9 @@ object RemoteConnectionManagerWithMockProviderSpec {
 
   val defalutAllowed = Secp256k1Key.getFakeRandomKey
   val defaultToMake  = Secp256k1Key.getFakeRandomKey
+
+  implicit val tracers: NetworkTracers[Task, Secp256k1Key, TestMessage] =
+    NetworkTracers(Tracer.noOpTracer)
 
   def buildConnectionsManagerWithMockProvider(
       ec: MockEncryptedConnectionProvider,

--- a/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithMockProviderSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithMockProviderSpec.scala
@@ -18,7 +18,7 @@ import io.iohk.metronome.networking.RemoteConnectionManagerWithMockProviderSpec.
   fakeLocalAddress,
   longRetryConfig
 }
-import io.iohk.tracer.Tracer
+import io.iohk.metronome.tracer.Tracer
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.flatspec.AsyncFlatSpecLike

--- a/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
@@ -151,6 +151,7 @@ object RemoteConnectionManagerWithScalanetProviderSpec {
         level = _ => HybridLogObject.Level.Debug,
         message = _.getClass.getSimpleName,
         event = {
+          case e: ConnectionUnknown[_]      => e.peer.asJsonObject
           case e: ConnectionRegistered[_]   => e.peer.asJsonObject
           case e: ConnectionDeregistered[_] => e.peer.asJsonObject
           case e: ConnectionDiscarded[_]    => e.peer.asJsonObject

--- a/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
@@ -14,7 +14,6 @@ import io.iohk.metronome.networking.RemoteConnectionManagerWithScalanetProviderS
   Cluster,
   buildTestConnectionManager
 }
-import io.iohk.metronome.tracer.Tracer
 import io.iohk.metronome.logging.{HybridLogObject, HybridLog, LogTracer}
 import io.iohk.scalanet.peergroup.PeerGroup
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.FramingConfig
@@ -28,7 +27,6 @@ import java.net.InetSocketAddress
 import java.security.SecureRandom
 import scala.concurrent.duration._
 import monix.execution.UncaughtExceptionReporter
-import cats.Applicative
 
 class RemoteConnectionManagerWithScalanetProviderSpec
     extends AsyncFlatSpecLike
@@ -140,7 +138,6 @@ object RemoteConnectionManagerWithScalanetProviderSpec {
   // Just an example of setting up logging.
   implicit def tracers[F[_]: Sync, K: io.circe.Encoder, M]
       : NetworkTracers[F, K, M] = {
-    import cats.implicits._
     import io.circe.syntax._
     import NetworkEvent._
 

--- a/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
@@ -146,8 +146,8 @@ object RemoteConnectionManagerWithScalanetProviderSpec {
         JsonObject("key" -> key.asJson, "address" -> address.toString.asJson)
       }
 
-    implicit val hybridLog: HybridLog[NetworkEvent[K]] =
-      HybridLog.instance[NetworkEvent[K]](
+    implicit val hybridLog: HybridLog[NetworkEvent[K, M]] =
+      HybridLog.instance[NetworkEvent[K, M]](
         level = _ => HybridLogObject.Level.Debug,
         message = _.getClass.getSimpleName,
         event = {
@@ -155,14 +155,17 @@ object RemoteConnectionManagerWithScalanetProviderSpec {
           case e: ConnectionRegistered[_]   => e.peer.asJsonObject
           case e: ConnectionDeregistered[_] => e.peer.asJsonObject
           case e: ConnectionDiscarded[_]    => e.peer.asJsonObject
+          case e: ConnectionSendError[_]    => e.peer.asJsonObject
           case e: ConnectionFailed[_] =>
             e.peer.asJsonObject.add("error", e.error.toString.asJson)
-          case e: ConnectionError[_] =>
+          case e: ConnectionReceiveError[_] =>
             e.peer.asJsonObject.add("error", e.error.toString.asJson)
+          case e: NetworkEvent.MessageReceived[_, _] => e.peer.asJsonObject
+          case e: NetworkEvent.MessageSent[_, _]     => e.peer.asJsonObject
         }
       )
 
-    NetworkTracers(LogTracer.hybrid[F, NetworkEvent[K]])
+    NetworkTracers(LogTracer.hybrid[F, NetworkEvent[K, M]])
   }
 
   def buildTestConnectionManager[

--- a/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
@@ -2,7 +2,8 @@ package io.iohk.metronome.networking
 
 import cats.data.NonEmptyList
 import cats.effect.concurrent.Ref
-import cats.effect.{Concurrent, ContextShift, Resource, Timer}
+import cats.effect.{Concurrent, ContextShift, Resource, Timer, Sync}
+import io.circe.{Json, JsonObject, Encoder}
 import io.iohk.metronome.networking.ConnectionHandler.MessageReceived
 import io.iohk.metronome.networking.RemoteConnectionManager.{
   ClusterConfig,
@@ -13,16 +14,16 @@ import io.iohk.metronome.networking.RemoteConnectionManagerWithScalanetProviderS
   Cluster,
   buildTestConnectionManager
 }
+import io.iohk.metronome.tracer.Tracer
+import io.iohk.metronome.logging.{HybridLogObject, HybridLog}
 import io.iohk.scalanet.peergroup.PeerGroup
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.FramingConfig
-import io.iohk.tracer.Tracer
 import monix.eval.{Task, TaskLift, TaskLike}
 import monix.execution.Scheduler
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.scalatest.flatspec.AsyncFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import scodec.Codec
-
 import java.net.InetSocketAddress
 import java.security.SecureRandom
 import scala.concurrent.duration._
@@ -32,6 +33,8 @@ import cats.Applicative
 class RemoteConnectionManagerWithScalanetProviderSpec
     extends AsyncFlatSpecLike
     with Matchers {
+  import RemoteConnectionManagerWithScalanetProviderSpec.secp256k1Encoder
+
   implicit val testScheduler =
     Scheduler.fixedPool(
       "RemoteConnectionManagerSpec",
@@ -131,12 +134,59 @@ object RemoteConnectionManagerWithScalanetProviderSpec {
     FramingConfig.buildStandardFrameConfig(1000000, 4).getOrElse(null)
   val testIncomingQueueSize = 20
 
-  implicit def tracers[F[_]: Applicative, K, M]: NetworkTracers[F, K, M] =
-    NetworkTracers(Tracer.noOpTracer)
+  implicit val secp256k1Encoder: Encoder[Secp256k1Key] =
+    Encoder.instance(key => Json.fromString(key.key.toHex))
+
+  // Just an example of printing logs to STDOUT.
+  // We could instead collect them in memory on a test by test basis.
+  val printLogs = false
+
+  // Just an example of setting up logging.
+  implicit def tracers[F[_]: Sync, K: io.circe.Encoder, M]
+      : NetworkTracers[F, K, M] = {
+    import cats.implicits._
+    import io.circe.syntax._
+    import NetworkEvent._
+
+    val hybridLog: HybridLog[NetworkEvent[K]] =
+      HybridLog.instance[NetworkEvent[K]](
+        source = "networking".some,
+        level = _ => HybridLogObject.Level.Debug,
+        message = {
+          case _: ConnectionRegistered[_]   => "Connection registered."
+          case _: ConnectionDeregistered[_] => "Connection deregistered."
+          case _: ConnectionDiscarded[_]    => "Connection discarded."
+          case _: ConnectionFailed[_]       => "Connection failed."
+        },
+        event = {
+          case e: ConnectionRegistered[_]   => JsonObject("key" -> e.key.asJson)
+          case e: ConnectionDeregistered[_] => JsonObject("key" -> e.key.asJson)
+          case e: ConnectionDiscarded[_]    => JsonObject("key" -> e.key.asJson)
+          case e: ConnectionFailed[_] =>
+            JsonObject(
+              "key" -> e.failure.connectionRequest.key.asJson,
+              "err" -> e.failure.err.getMessage.asJson
+            )
+        }
+      )
+
+    val logTracer: Tracer[F, HybridLogObject] =
+      Tracer.showTracing {
+        new Tracer[F, String] {
+          override def apply(a: => String): F[Unit] =
+            Sync[F].delay(println(a)).whenA(printLogs)
+        }
+      }
+
+    val networkEventTracer: Tracer[F, NetworkEvent[K]] =
+      logTracer.contramap(event => hybridLog(event))
+
+    NetworkTracers(networkEventTracer)
+  }
 
   def buildTestConnectionManager[
       F[_]: Concurrent: TaskLift: TaskLike: Timer,
-      K: Codec,
+      K: Codec: Encoder,
       M: Codec
   ](
       bindAddress: InetSocketAddress = randomAddress(),

--- a/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithScalanetProviderSpec.scala
@@ -15,6 +15,7 @@ import io.iohk.metronome.networking.RemoteConnectionManagerWithScalanetProviderS
 }
 import io.iohk.scalanet.peergroup.PeerGroup
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.FramingConfig
+import io.iohk.tracer.Tracer
 import monix.eval.{Task, TaskLift, TaskLike}
 import monix.execution.Scheduler
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
@@ -26,6 +27,7 @@ import java.net.InetSocketAddress
 import java.security.SecureRandom
 import scala.concurrent.duration._
 import monix.execution.UncaughtExceptionReporter
+import cats.Applicative
 
 class RemoteConnectionManagerWithScalanetProviderSpec
     extends AsyncFlatSpecLike
@@ -128,6 +130,9 @@ object RemoteConnectionManagerWithScalanetProviderSpec {
   val standardFraming =
     FramingConfig.buildStandardFrameConfig(1000000, 4).getOrElse(null)
   val testIncomingQueueSize = 20
+
+  implicit def tracers[F[_]: Applicative, K, M]: NetworkTracers[F, K, M] =
+    NetworkTracers(Tracer.noOpTracer)
 
   def buildTestConnectionManager[
       F[_]: Concurrent: TaskLift: TaskLike: Timer,

--- a/metronome/tracing/src/main/scala/io/iohk/metronome/tracer/Tracer.scala
+++ b/metronome/tracing/src/main/scala/io/iohk/metronome/tracer/Tracer.scala
@@ -1,4 +1,4 @@
-package io.iohk.tracer
+package io.iohk.metronome.tracer
 
 import language.higherKinds
 import cats.{Applicative, Contravariant, FlatMap, Id, Monad, Monoid, Show, ~>}
@@ -17,6 +17,8 @@ object Tracer {
     * - how to enrich type A that is traced
     * - how to squeeze B's to create A's (possibly enrich B with extra stuff, or forget some details)
     * then you have Tracer for B
+    *
+    * To use this, just import `cats` syntax for `Contravariant` and call `.contramap` on `A`.
     */
   implicit def contraTracer[F[_]]: Contravariant[Tracer[F, *]] =
     new Contravariant[Tracer[F, *]] {

--- a/metronome/tracing/src/main/scala/io/iohk/metronome/tracer/Tracer.scala
+++ b/metronome/tracing/src/main/scala/io/iohk/metronome/tracer/Tracer.scala
@@ -3,7 +3,7 @@ package io.iohk.metronome.tracer
 import language.higherKinds
 import cats.{Applicative, Contravariant, FlatMap, Id, Monad, Monoid, Show, ~>}
 
-/** Contravariant tracer
+/** Contravariant tracer.
   *
   * Ported from https://github.com/input-output-hk/contra-tracer/blob/master/src/Control/Tracer.hs
   */

--- a/metronome/tracing/src/main/scala/io/iohk/metronome/tracer/Tracer.scala
+++ b/metronome/tracing/src/main/scala/io/iohk/metronome/tracer/Tracer.scala
@@ -13,6 +13,14 @@ trait Tracer[F[_], -A] {
 
 object Tracer {
 
+  def instance[F[_], A](f: (=> A) => F[Unit]): Tracer[F, A] =
+    new Tracer[F, A] {
+      override def apply(a: => A): F[Unit] = f(a)
+    }
+
+  def const[F[_], A](f: F[Unit]): Tracer[F, A] =
+    instance(_ => f)
+
   /** If you know:
     * - how to enrich type A that is traced
     * - how to squeeze B's to create A's (possibly enrich B with extra stuff, or forget some details)

--- a/metronome/tracing/src/main/scala/io/iohk/metronome/tracer/Tracer.scala
+++ b/metronome/tracing/src/main/scala/io/iohk/metronome/tracer/Tracer.scala
@@ -26,7 +26,13 @@ object Tracer {
     * - how to squeeze B's to create A's (possibly enrich B with extra stuff, or forget some details)
     * then you have Tracer for B
     *
-    * To use this, just import `cats` syntax for `Contravariant` and call `.contramap` on `A`.
+    * Example
+    * ```
+    * import cats.syntax.contravariant._
+    *
+    * val atracer: Tracer[F, A] = ???
+    * val btracer: Tracer[F, B] = atracer.contramap[B](b => b.toA)
+    * ```.
     */
   implicit def contraTracer[F[_]]: Contravariant[Tracer[F, *]] =
     new Contravariant[Tracer[F, *]] {


### PR DESCRIPTION
Adds structured logging to capture some network events via tracing. The logs are only demonstrated in the tests (and only visible if the log level in `networking/test/resources/logback.xml` is adjusted from `ERROR` to `DEBUG`).

Adopted a [hybrid log format](https://medium.com/unomaly/logging-wisdom-how-to-log-5a19145e35ec) consisting of a human readable `message` and key-value pairs in the form of a JSON object in `event`.

The resulting logs look like this:
```
21:25:44.871 DEBUG i.i.m.networking.NetworkEvent ConnectionFailed {"key":"1bc14e1ac7f929c83b05d796a591c272e36ab7a6e71df41c330c1e21d377af6d300cb73a9395da68708fc2d05c0cd1800b4d07dcf88940f05b161277da4926cd","address":"localhost/127.0.0.1:45765","err":"Error establishing channel to PeerInfo(BitVector(512 bits, 0x1bc14e1ac7f929c83b05d796a591c272e36ab7a6e71df41c330c1e21d377af6d300cb73a9395da68708fc2d05c0cd1800b4d07dcf88940f05b161277da4926cd),localhost/127.0.0.1:45765)."}
21:25:44.905 DEBUG i.i.m.networking.NetworkEvent ConnectionRegistered {"key":"98e7fdb3b38f7a15ec8f9feb407460996db4b075869930571503ba47af0a96341c8d07c97031b839874451a748a0d28b35f47f7a53f22a086eba5045b0a74d08","address":"localhost/127.0.0.1:46251"}
```

There's also a class to help collect the logs in memory, so we can assert for example that no warnings have been emitted, or set up multiple nodes in integration tests and add their hostname to the logs on the fly, which can help debugging issues. 

`NetworkTracers` is a case class so we can individually compose tracers for separate events using `copy`, for example to disable one by replacing it with `Tracer.noOpTracer` or later to enhance by adding metrics, something like this:

```scala
implicit val networkTracers: Tracer[F, NetworkEvent[K]] = {
  val log = NetworkTracers(LogTracer.hybrid[F, NetworkEvent[K]])
  val registered = Metrics.gauge("connections")
  log.copy(
    registered = log.registered |+| Tracer.const(Sync[F].delay(registered.increment())),
    deregistered = log.deregistered |+| Tracer.const(Sync[F].delay(registered.decrement()))
  )
}
```

Silenced logs from Scalanet in tests.