### PR TITLE
PM-2929: Transaction data structure.

### DIFF
--- a/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/models/Transaction.scala
+++ b/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/models/Transaction.scala
@@ -1,0 +1,54 @@
+package io.iohk.metronome.checkpointing.interpreter.models
+
+import scodec.bits.BitVector
+
+/** Transactions are what comprise the block body used by the Checkpointing Service.
+  *
+  * The HotStuff BFT Agreement doesn't need to know about them, their execution and
+  * validation is delegated to the Checkpointing Service, which, in turn, delegates
+  * to the interpreter. The only component that truly has to understand the contents
+  * is the PoW specific interpreter.
+  *
+  * What the Checkpointing Service has to know is the different kinds of transactions
+  * we support, which is to register proposer blocks in the ledger, required by Advocate,
+  * and to register checkpoint candidates.
+  */
+sealed trait Transaction
+
+object Transaction {
+
+  /** In PoW chains that support Advocate checkpointing, the Checkpoint Certificate
+    * can enforce the inclusion of proposed blocks on the chain via references; think
+    * uncle blocks that also get executed.
+    *
+    * In order to know which proposed blocks can be enforced, i.e. ones that are valid
+    * and have saturated the network, first the federation members need to reach BFT
+    * agreement over the list of existing proposer blocks.
+    *
+    * The `ProposerBlock` transaction adds one of these blocks that exist on the PoW
+    * chain to the Checkpointing Ledger, iff it can be validated by the members.
+    *
+    * The contents of the transaction are opaque, they only need to be understood
+    * by the PoW side interpreter.
+    *
+    * Using Advocate is optional; if the PoW chain doesn't support references,
+    * it will just use `CheckpointCandidate` transactions.
+    */
+  case class ProposerBlock(value: BitVector) extends Transaction
+
+  /** When a federation member is leading a round, it will ask the PoW side interpreter
+    * if it wants to propose a checkpoint candidate. The interpreter decides if the
+    * circumstances are right, e.g. enough new blocks have been build on the previous
+    * checkpoint that a new one has to be issued. If so, a `CheckpointCandidate`
+    * transaction is added to the next block, which is sent to the HotStuff replicas
+    * in a `Prepare` message, to be validated and committed.
+    *
+    * If the BFT agreement is successful, a Checkpoint Certificate will be formed
+    * during block execution which will include the `CheckpointCandidate`.
+    *
+    * The contents of the transaction are opaque, they only need to be understood
+    * by teh PoW side interpreter, either for validation, or for following the
+    * fork indicated by the checkpoint.
+    */
+  case class CheckpointCandidate(value: BitVector) extends Transaction
+}


### PR DESCRIPTION
Adds the most minimalistic `Transaction` type I can think of. 

I think these can become part of the ledger as-is. 

So far we haven't discovered a need for the service to know the `height` of the proposer blocks and the checkpoint candidate. I thought this could be relevant during the update of the ledger: say we have to checkpoint every 10th height in the chain, there's no checkpoint yet for height 100, and we have these events:
1. Alice adds a proposer block transaction for level 101
1. Bob adds a checkpoint candidate for level 100 - it probably cannot enforce the inclusion of Alice's proposer at level 101
1. The ledger is updated, the accumulated proposer blocks are discarded, the new checkpoint is the one sent by Bob - should we keep Alice's proposer block in the ledger?

During our discussions I think @ranvirranaiitb said that if Alice was honest she'd have added a checkpoint candidate for level 100 if she has something to say about level 101. In that case perhaps she could have got the checkpoint in, clear the ledger, then process the next transaction which adds the new proposer at level 101, all without the checkpoint service having to know the heights. 

Another alternative is to return in a response from the interpreter which proposer block entries can be cleared from the ledger, after the execution of a block. 

Other fields that came to mind are timestamp, or signatures, but it doesn't seem like there's any use for those. Not even the block needs to be signed, since it can only arrive in a Prepare message from the leader, and after that everyone signs it via Votes. 

I thought about making this generic, so in the service side it can be something like `CheckpointCandidate[BitVector]`, while on the interpreter side it can be a `CheckpointCandiate[Vector[VoterBlock.Hash]]`. Not sure if that would make it easier or more difficult to understand: the idea is that the `checkpointing.interpreter` module is a library that is independent of the PoW domain, so for this interpreter it's opaque, and that's emphasized by the fact that it's just a `BitVector`. The raw data has to be packed/unpacked explicitly by the ETC interpreter.

