### PR TITLE
PM-2930: Block data structure

### DIFF
--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
@@ -34,6 +34,11 @@ object Block {
 
   case class Header(
       parentHash: Hash,
+      // Hash of the Ledger before executing the block.
+      preStateHash: Hash,
+      // Hash of the Ledger after executing the block.
+      postStateHash: Hash,
+      // Hash of the transactions in the body.
       bodyHash: Hash
   ) extends RLPHash[Header] {
     protected override val encoder = RLPCodecs.rlpBlockHeader

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
@@ -6,6 +6,13 @@ import io.iohk.metronome.checkpointing.interpreter.models.Transaction
   * with the transactions in the body being the "commands".
   *
   * The block contents are specific to the checkpointing application.
+  *
+  * The header and body are separated because headers have to part
+  * of the Checkpoint Certificate; there's no need to repeat all
+  * the transactions there, the Merkle root will make it possible
+  * to prove that a given CheckpointCandidate transaction was
+  * indeed part of the block. The headers are needed for parent-child
+  * validation in the certificate as well.
   */
 sealed abstract case class Block(
     header: Block.Header,
@@ -39,6 +46,10 @@ object Block {
       postStateHash: Ledger.Hash,
       // Hash of the transactions in the body.
       bodyHash: Body.Hash
+      // TODO (PM-3102): Add merkle root for contents.
+      // Instead of the hash of the body, should we use the
+      // the Merkle root of the transactions?
+      // Or should that be an additional field?
   ) extends RLPHash[Header, Header.Hash]
 
   object Header extends RLPHashCompanion[Header]()(RLPCodecs.rlpBlockHeader)

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
@@ -40,8 +40,6 @@ object Block {
 
   case class Header(
       parentHash: Header.Hash,
-      // Hash of the Ledger before executing the block.
-      preStateHash: Ledger.Hash,
       // Hash of the Ledger after executing the block.
       postStateHash: Ledger.Hash,
       // Hash of the transactions in the body.

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
@@ -1,0 +1,47 @@
+package io.iohk.metronome.checkpointing.service.models
+
+import io.iohk.metronome.checkpointing.interpreter.models.Transaction
+import io.iohk.metronome.crypto.hash.Hash
+
+/** Represents what the HotStuff paper called "nodes" as the "tree",
+  * with the transactions in the body being the "commands".
+  *
+  * The block contents are specific to the checkpointing application.
+  */
+sealed abstract case class Block(
+    header: Block.Header,
+    body: Block.Body
+) {
+  def hash: Hash = header.hash
+}
+
+object Block {
+
+  /** Create a from a header and body we received from the network.
+    * It will need to be validated before it can be used, to make sure
+    * the header really belongs to the body.
+    */
+  def makeUnsafe(header: Header, body: Body): Block =
+    new Block(header, body) {}
+
+  /** Create a block from a header and a body, updating the `bodyHash` in the
+    * header to make sure the final block hash is valid.
+    */
+  def make(
+      header: Header,
+      body: Body
+  ) = makeUnsafe(header = header.copy(bodyHash = body.hash), body = body)
+
+  case class Header(
+      parentHash: Hash,
+      bodyHash: Hash
+  ) extends RLPHash[Header] {
+    protected override val encoder = RLPCodecs.rlpBlockHeader
+  }
+
+  case class Body(
+      transactions: Vector[Transaction]
+  ) extends RLPHash[Body] {
+    protected override val encoder = RLPCodecs.rlpBlockBody
+  }
+}

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Block.scala
@@ -1,7 +1,6 @@
 package io.iohk.metronome.checkpointing.service.models
 
 import io.iohk.metronome.checkpointing.interpreter.models.Transaction
-import io.iohk.metronome.crypto.hash.Hash
 
 /** Represents what the HotStuff paper called "nodes" as the "tree",
   * with the transactions in the body being the "commands".
@@ -12,7 +11,7 @@ sealed abstract case class Block(
     header: Block.Header,
     body: Block.Body
 ) {
-  def hash: Hash = header.hash
+  def hash: Block.Header.Hash = header.hash
 }
 
 object Block {
@@ -33,20 +32,20 @@ object Block {
   ) = makeUnsafe(header = header.copy(bodyHash = body.hash), body = body)
 
   case class Header(
-      parentHash: Hash,
+      parentHash: Header.Hash,
       // Hash of the Ledger before executing the block.
-      preStateHash: Hash,
+      preStateHash: Ledger.Hash,
       // Hash of the Ledger after executing the block.
-      postStateHash: Hash,
+      postStateHash: Ledger.Hash,
       // Hash of the transactions in the body.
-      bodyHash: Hash
-  ) extends RLPHash[Header] {
-    protected override val encoder = RLPCodecs.rlpBlockHeader
-  }
+      bodyHash: Body.Hash
+  ) extends RLPHash[Header, Header.Hash]
+
+  object Header extends RLPHashCompanion[Header]()(RLPCodecs.rlpBlockHeader)
 
   case class Body(
       transactions: Vector[Transaction]
-  ) extends RLPHash[Body] {
-    protected override val encoder = RLPCodecs.rlpBlockBody
-  }
+  ) extends RLPHash[Body, Body.Hash]
+
+  object Body extends RLPHashCompanion[Body]()(RLPCodecs.rlpBlockBody)
 }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Ledger.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Ledger.scala
@@ -1,9 +1,7 @@
 package io.iohk.metronome.checkpointing.service.models
 
-import io.iohk.ethereum.rlp
 import io.iohk.metronome.core.Validated
 import io.iohk.metronome.checkpointing.interpreter.models.Transaction
-import io.iohk.metronome.crypto.hash.{Hash, Keccak256}
 
 /** Current state of the ledger after applying all previous blocks.
   *
@@ -16,12 +14,8 @@ import io.iohk.metronome.crypto.hash.{Hash, Keccak256}
 case class Ledger(
     maybeLastCheckpoint: Option[Transaction.CheckpointCandidate],
     proposerBlocks: Vector[Transaction.ProposerBlock]
-) {
-
-  /** Calculate the hash of the ledger so we can put it in blocks
-    * and refer to it when syncing state between federation members.
-    */
-  lazy val hash: Hash = Ledger.hash(this)
+) extends RLPHash[Ledger] {
+  override protected val encoder = RLPCodecs.rlpLedger
 
   /** Apply a validated transaction to produce the next ledger state.
     *
@@ -44,9 +38,4 @@ case class Ledger(
 
 object Ledger {
   val empty = Ledger(None, Vector.empty)
-
-  def hash(ledger: Ledger): Hash = {
-    import RLPCodecs._
-    Keccak256(rlp.encode(ledger))
-  }
 }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Ledger.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/Ledger.scala
@@ -14,8 +14,7 @@ import io.iohk.metronome.checkpointing.interpreter.models.Transaction
 case class Ledger(
     maybeLastCheckpoint: Option[Transaction.CheckpointCandidate],
     proposerBlocks: Vector[Transaction.ProposerBlock]
-) extends RLPHash[Ledger] {
-  override protected val encoder = RLPCodecs.rlpLedger
+) extends RLPHash[Ledger, Ledger.Hash] {
 
   /** Apply a validated transaction to produce the next ledger state.
     *
@@ -36,6 +35,6 @@ case class Ledger(
     }
 }
 
-object Ledger {
+object Ledger extends RLPHashCompanion[Ledger]()(RLPCodecs.rlpLedger) {
   val empty = Ledger(None, Vector.empty)
 }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPCodecs.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPCodecs.scala
@@ -19,6 +19,15 @@ object RLPCodecs {
   implicit val hashRLPCodec: RLPCodec[Hash] =
     implicitly[RLPCodec[ByteVector]].xmap(Hash(_), identity)
 
+  implicit val headerHashRLPCodec: RLPCodec[Block.Header.Hash] =
+    implicitly[RLPCodec[ByteVector]].xmap(Block.Header.Hash(_), identity)
+
+  implicit val bodyHashRLPCodec: RLPCodec[Block.Body.Hash] =
+    implicitly[RLPCodec[ByteVector]].xmap(Block.Body.Hash(_), identity)
+
+  implicit val ledgerHashRLPCodec: RLPCodec[Ledger.Hash] =
+    implicitly[RLPCodec[ByteVector]].xmap(Ledger.Hash(_), identity)
+
   implicit val rlpProposerBlock: RLPCodec[Transaction.ProposerBlock] =
     deriveLabelledGenericRLPCodec
 

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPCodecs.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPCodecs.scala
@@ -4,6 +4,8 @@ import io.iohk.ethereum.rlp.RLPCodec
 import io.iohk.ethereum.rlp.RLPCodec.Ops
 import io.iohk.ethereum.rlp.RLPImplicitDerivations._
 import io.iohk.ethereum.rlp.RLPImplicits._
+import io.iohk.ethereum.rlp.{RLPEncoder, RLPList}
+import io.iohk.metronome.crypto.hash.Hash
 import io.iohk.metronome.checkpointing.interpreter.models.Transaction
 import scodec.bits.{BitVector, ByteVector}
 
@@ -13,6 +15,9 @@ object RLPCodecs {
 
   implicit val rlpByteVector: RLPCodec[ByteVector] =
     implicitly[RLPCodec[Array[Byte]]].xmap(ByteVector(_), _.toArray)
+
+  implicit val hashRLPCodec: RLPCodec[Hash] =
+    implicitly[RLPCodec[ByteVector]].xmap(Hash(_), identity)
 
   implicit val rlpProposerBlock: RLPCodec[Transaction.ProposerBlock] =
     deriveLabelledGenericRLPCodec
@@ -26,4 +31,57 @@ object RLPCodecs {
 
   implicit val rlpLedger: RLPCodec[Ledger] =
     deriveLabelledGenericRLPCodec
+
+  implicit val rlpTransaction: RLPCodec[Transaction] = {
+    import Transaction._
+
+    val ProposerBlockTag: Short       = 1
+    val CheckpointCandidateTag: Short = 2
+
+    def encodeWithTag[T: RLPEncoder](tag: Short, value: T) = {
+      val t = RLPEncoder.encode(tag)
+      val l = RLPEncoder.encode(value).asInstanceOf[RLPList]
+      t +: l
+    }
+
+    RLPCodec.instance[Transaction](
+      {
+        case tx: ProposerBlock =>
+          encodeWithTag(ProposerBlockTag, tx)
+        case tx: CheckpointCandidate =>
+          encodeWithTag(CheckpointCandidateTag, tx)
+      },
+      { case RLPList(tag, items @ _*) =>
+        val rest = RLPList(items: _*)
+        tag.decodeAs[Short]("tag") match {
+          case ProposerBlockTag =>
+            rest.decodeAs[ProposerBlock]("transaction")
+          case CheckpointCandidateTag =>
+            rest.decodeAs[CheckpointCandidate]("transaction")
+        }
+      }
+    )
+  }
+
+  implicit val rlpBlockBody: RLPCodec[Block.Body] =
+    deriveLabelledGenericRLPCodec
+
+  implicit val rlpBlockHeader: RLPCodec[Block.Header] =
+    deriveLabelledGenericRLPCodec
+
+  // Cannot use derivation because Block is a sealed abstract case class,
+  // so it doesn't allow creation of an invalid block.
+  implicit val rlpBlock: RLPCodec[Block] =
+    RLPCodec.instance[Block](
+      block =>
+        RLPList(
+          RLPEncoder.encode(block.header),
+          RLPEncoder.encode(block.body)
+        ),
+      { case RLPList(header, body) =>
+        val h = header.decodeAs[Block.Header]("header")
+        val b = body.decodeAs[Block.Body]("body")
+        Block.makeUnsafe(h, b)
+      }
+    )
 }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPHash.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPHash.scala
@@ -1,0 +1,18 @@
+package io.iohk.metronome.checkpointing.service.models
+
+import io.iohk.ethereum.rlp
+import io.iohk.ethereum.rlp.RLPEncoder
+import io.iohk.metronome.crypto.hash.{Hash, Keccak256}
+
+/** Calculate a hash based on the RLP representation of a value. */
+object RLPHash {
+  def apply[T: RLPEncoder](value: T): Hash =
+    Keccak256(rlp.encode(value))
+}
+
+/** Mixin for classes that need hashing based on their RLP representation. */
+trait RLPHash[T] { self: T =>
+  protected implicit def encoder: RLPEncoder[T]
+
+  lazy val hash = RLPHash[T](self)
+}

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPHash.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPHash.scala
@@ -2,17 +2,44 @@ package io.iohk.metronome.checkpointing.service.models
 
 import io.iohk.ethereum.rlp
 import io.iohk.ethereum.rlp.RLPEncoder
-import io.iohk.metronome.crypto.hash.{Hash, Keccak256}
+import io.iohk.metronome.crypto
+import io.iohk.metronome.crypto.hash.Keccak256
+import io.iohk.metronome.core.Tagger
+import scodec.bits.ByteVector
+import scala.language.implicitConversions
 
-/** Calculate a hash based on the RLP representation of a value. */
-object RLPHash {
-  def apply[T: RLPEncoder](value: T): Hash =
-    Keccak256(rlp.encode(value))
+/** Type class to produce a specific type of hash based on the RLP
+  * representation of a type, where the hash type is typically
+  * defined in the companion object of the type.
+  */
+trait RLPHasher[T] {
+  type Hash
+  def hash(value: T): Hash
+}
+object RLPHasher {
+  type Aux[T, H] = RLPHasher[T] {
+    type Hash = H
+  }
 }
 
-/** Mixin for classes that need hashing based on their RLP representation. */
-trait RLPHash[T] { self: T =>
-  protected implicit def encoder: RLPEncoder[T]
+/** Base class for types that have a hash value based on their RLP representation. */
+abstract class RLPHash[T, H](implicit ev: RLPHasher.Aux[T, H]) { self: T =>
+  lazy val hash: H = ev.hash(self)
+}
 
-  lazy val hash: Hash = RLPHash[T](self)
+/** Base class for companion objects for types that need hashes based on RLP.
+  *
+  * Every companion will define a separate `Hash` type, so we don't mix them up.
+  */
+abstract class RLPHashCompanion[T: RLPEncoder] extends RLPHasher[T] { self =>
+  object Hash extends Tagger[ByteVector]
+  override type Hash = Hash.Tagged
+
+  override def hash(value: T): Hash =
+    Hash(Keccak256(rlp.encode(value)))
+
+  implicit val hasher: RLPHasher.Aux[T, Hash] = this
+
+  implicit def `Hash => crypto.Hash`(h: Hash): crypto.hash.Hash =
+    crypto.hash.Hash(h)
 }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPHash.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/models/RLPHash.scala
@@ -14,5 +14,5 @@ object RLPHash {
 trait RLPHash[T] { self: T =>
   protected implicit def encoder: RLPEncoder[T]
 
-  lazy val hash = RLPHash[T](self)
+  lazy val hash: Hash = RLPHash[T](self)
 }

--- a/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/ArbitraryInstances.scala
+++ b/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/ArbitraryInstances.scala
@@ -58,13 +58,11 @@ object ArbitraryInstances {
     Arbitrary {
       for {
         parentHash    <- arbitrary[Block.Header.Hash]
-        preStateHash  <- arbitrary[Ledger.Hash]
         postStateHash <- arbitrary[Ledger.Hash]
         transactions  <- arbitrary[Vector[Transaction]]
         body = Block.Body(transactions)
         header = Block.Header(
           parentHash,
-          preStateHash,
           postStateHash,
           body.hash
         )

--- a/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/ArbitraryInstances.scala
+++ b/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/ArbitraryInstances.scala
@@ -48,10 +48,17 @@ object ArbitraryInstances {
   implicit val arbBlock: Arbitrary[Block] =
     Arbitrary {
       for {
-        parentHash   <- arbitrary[Hash]
-        transactions <- arbitrary[Vector[Transaction]]
-        body   = Block.Body(transactions)
-        header = Block.Header(parentHash, body.hash)
+        parentHash    <- arbitrary[Hash]
+        preStateHash  <- arbitrary[Hash]
+        postStateHash <- arbitrary[Hash]
+        transactions  <- arbitrary[Vector[Transaction]]
+        body = Block.Body(transactions)
+        header = Block.Header(
+          parentHash,
+          preStateHash,
+          postStateHash,
+          body.hash
+        )
       } yield Block.make(header, body)
     }
 }

--- a/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/ArbitraryInstances.scala
+++ b/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/ArbitraryInstances.scala
@@ -18,6 +18,15 @@ object ArbitraryInstances {
       Gen.listOfN(32, arbitrary[Byte]).map(ByteVector(_)).map(Hash(_))
     }
 
+  implicit val arbHeaderHash: Arbitrary[Block.Header.Hash] =
+    Arbitrary(arbitrary[Hash].map(Block.Header.Hash(_)))
+
+  implicit val arbBodyHash: Arbitrary[Block.Body.Hash] =
+    Arbitrary(arbitrary[Hash].map(Block.Body.Hash(_)))
+
+  implicit val arbLedgerHash: Arbitrary[Ledger.Hash] =
+    Arbitrary(arbitrary[Hash].map(Ledger.Hash(_)))
+
   implicit val arbProposerBlock: Arbitrary[Transaction.ProposerBlock] =
     Arbitrary {
       arbitrary[BitVector].map(Transaction.ProposerBlock(_))
@@ -48,9 +57,9 @@ object ArbitraryInstances {
   implicit val arbBlock: Arbitrary[Block] =
     Arbitrary {
       for {
-        parentHash    <- arbitrary[Hash]
-        preStateHash  <- arbitrary[Hash]
-        postStateHash <- arbitrary[Hash]
+        parentHash    <- arbitrary[Block.Header.Hash]
+        preStateHash  <- arbitrary[Ledger.Hash]
+        postStateHash <- arbitrary[Ledger.Hash]
         transactions  <- arbitrary[Vector[Transaction]]
         body = Block.Body(transactions)
         header = Block.Header(

--- a/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/RLPCodecsProps.scala
+++ b/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/RLPCodecsProps.scala
@@ -2,6 +2,7 @@ package io.iohk.metronome.checkpointing.service.models
 
 import io.iohk.ethereum.rlp
 import io.iohk.ethereum.rlp.RLPCodec
+import io.iohk.metronome.checkpointing.interpreter.models.Transaction
 import org.scalacheck._
 import org.scalacheck.Prop.forAll
 import scala.reflect.ClassTag
@@ -20,4 +21,6 @@ object RLPCodecsProps extends Properties("RLPCodecs") {
     }
 
   propRoundTrip[Ledger]
+  propRoundTrip[Transaction]
+  propRoundTrip[Block]
 }

--- a/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/RLPCodecsSpec.scala
+++ b/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/models/RLPCodecsSpec.scala
@@ -74,9 +74,9 @@ class RLPCodecsSpec extends AnyFlatSpec with Matchers {
         )
       )
 
-      override val decoded: Ledger = ledger
+      override val decoded = ledger
 
-      override val encoded: RLPEncodeable =
+      override val encoded =
         RLPList(     // Ledger
           RLPList(   // Option
             RLPList( // CheckpointCandidate
@@ -89,6 +89,20 @@ class RLPCodecsSpec extends AnyFlatSpec with Matchers {
             ),
             RLPList(RLPValue(ledger.proposerBlocks(1).value.toByteArray))
           )
+        )
+    }
+  }
+
+  test {
+    new Example[Transaction] {
+      val transaction = sample[Transaction.ProposerBlock]
+
+      override val decoded = transaction
+
+      override val encoded =
+        RLPList(                     // ProposerBlock
+          RLPValue(Array(1.toByte)), // Tag
+          RLPValue(transaction.value.toByteArray)
         )
     }
   }


### PR DESCRIPTION
Creates a `Block` data structure with a `Block.Header` and `Block.Body` part. I thought it would have actually eliminated some possible hash mismatches if the header and body wasn't separated, but in the concept document the working theory was that the Checkpoint Certificate will have a list of block headers in it, so I stick to it. I guess it's conventional as well to separate the two.

Introduced separate `Hash` types for each of `Header`, `Body` and `Ledger`. 

__Questions__

Do we want to add more fields to the `Block.Header`?
* `height`: When someone proposes a block to us, and we miss its parent, we could look at the last block we have a cetificate for and ask for a whole range of blocks, rather than one by one, following parent-child relationships. It could also help with pruning old blocks if we had stored them by height.
* `viewNumber`: Every `Propose` message has a block in it that matches its view number. If we're missing blocks, we could follow the parents and make sure that every block along the way was created by a federation member that lead that view; however, you can only extend blocks that have a _Prepare Q.C._ so we shouldn't have a chain of blocks that aren't supported by some quorum along the way, which has the `viewNumber` in it.
* `creatorPublicKey`: Shouldn't be necessary if we can show a _Prepare Q.C._ that signed the `blockHash`.
* `creatorSignature`: It could support the claim that the block matches what the creator proposed, but it shouldn't be necessary as long as a _Prepare Q.C._ is available. And since we receive the block right from the leader in `Prepare`, over an authenticated channel, there's no need to sign the content.

We could also remove `preStateHash` to save some space, it's just a copy of the `postStateHash` from the parent of the block.

__Note__

I noticed in https://github.com/input-output-hk/metronome/pull/20 that these models have to be visible to the interpreter and the PoW chain after all, because they are part of the Checkpoint Certificate, to provide proof of the BFT agreement. The code has been moved around in that PR.