### PR TITLE
[PM-3092] Replace duplicated connections

### DIFF
--- a/metronome/networking/src/io/iohk/metronome/networking/ConnectionHandler.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/ConnectionHandler.scala
@@ -164,9 +164,10 @@ class ConnectionHandler[F[_]: Concurrent, K, M](
       case Some(oldConnection) =>
         //TODO [PM-3092] for now we are closing any new connections in case of conflict, we may investigate other strategies
         // like keeping old for outgoing and replacing for incoming
-        possibleNewConnection.close.as(None)
+        tracers.discarded(possibleNewConnection) >> possibleNewConnection.close.as(None)
       case None =>
-        Concurrent[F].pure(Some(possibleNewConnection))
+        tracers.registered(possibleNewConnection) >> Concurrent[F].pure(Some(possibleNewConnection))
+
     }
   }
 

--- a/metronome/networking/src/io/iohk/metronome/networking/ConnectionHandler.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/ConnectionHandler.scala
@@ -55,40 +55,33 @@ class ConnectionHandler[F[_]: Concurrent, K, M](
     }
   }
 
-  /** Registers connections and start handling incoming messages in background, in case connection is already handled
+  /** Registers incoming connections and start handling incoming messages in background, in case connection is already handled
     * it closes it
     *
-    * @param possibleNewConnection, possible connection to handle
+    * @param serverAddress, server address of incoming connection which should already be known
+    * @param encryptedConnection, established connection
     */
-  private def registerOrClose(
-      possibleNewConnection: HandledConnection[F, K, M]
-  ): F[Unit] = {
-    connectionsRegister.registerIfAbsent(possibleNewConnection).flatMap {
-      case Some(_) =>
-        //TODO [PM-3092] for now we are closing any new connections in case of conflict, we may investigate other strategies
-        // like keeping old for outgoing and replacing for incoming
-        tracers.discarded(possibleNewConnection) >>
-          possibleNewConnection.close
-
-      case None =>
-        tracers.registered(possibleNewConnection) >>
-          connectionQueue.offer(possibleNewConnection)
-    }
-  }
-
   def registerIncoming(
       serverAddress: InetSocketAddress,
       encryptedConnection: EncryptedConnection[F, K, M]
   ): F[Unit] = {
-    registerOrClose(
-      HandledConnection.incoming(serverAddress, encryptedConnection)
-    )
+    HandledConnection
+      .incoming(serverAddress, encryptedConnection)
+      .flatMap(connection => connectionQueue.offer(connection))
+
   }
 
+  /** Registers out connections and start handling incoming messages in background, in case connection is already handled
+    * it closes it
+    *
+    * @param encryptedConnection, established connection
+    */
   def registerOutgoing(
       encryptedConnection: EncryptedConnection[F, K, M]
   ): F[Unit] = {
-    registerOrClose(HandledConnection.outgoing(encryptedConnection))
+    HandledConnection
+      .outgoing(encryptedConnection)
+      .flatMap(connection => connectionQueue.offer(connection))
   }
 
   /** Checks if handler already handles connection o peer with provided key
@@ -164,6 +157,19 @@ class ConnectionHandler[F[_]: Concurrent, K, M](
     }
   }
 
+  private def registerOrDiscard(
+      possibleNewConnection: HandledConnection[F, K, M]
+  ): F[Option[HandledConnection[F, K, M]]] = {
+    connectionsRegister.registerIfAbsent(possibleNewConnection).flatMap {
+      case Some(oldConnection) =>
+        //TODO [PM-3092] for now we are closing any new connections in case of conflict, we may investigate other strategies
+        // like keeping old for outgoing and replacing for incoming
+        possibleNewConnection.close.as(None)
+      case None =>
+        Concurrent[F].pure(Some(possibleNewConnection))
+    }
+  }
+
   /** Connections multiplexer, it receives both incoming and outgoing connections and start reading incoming messages from
     * them concurrently, putting them on received messages queue.
     * In case of error or stream finish it cleans up all resources.
@@ -171,6 +177,8 @@ class ConnectionHandler[F[_]: Concurrent, K, M](
   private def handleConnections: F[Unit] = {
     Iterant
       .repeatEvalF(connectionQueue.poll)
+      .mapEval(registerOrDiscard)
+      .collect { case Some(conn) => conn }
       .mapEval { connection =>
         incrementRunningConnections >>
           Iterant
@@ -193,6 +201,7 @@ class ConnectionHandler[F[_]: Concurrent, K, M](
             }
             .guarantee(
               closeAndDeregisterConnection(connection)
+                .guarantee(connection.deregisterListener.complete(()))
                 .flatMap(_ => callCallBackIfNotClosed(connection))
             )
             .completedL
@@ -240,7 +249,8 @@ object ConnectionHandler {
   sealed abstract case class HandledConnection[F[_], K, M] private (
       key: K,
       serverAddress: InetSocketAddress,
-      underlyingConnection: EncryptedConnection[F, K, M]
+      underlyingConnection: EncryptedConnection[F, K, M],
+      deregisterListener: Deferred[F, Unit]
   ) {
     def sendMessage(m: M): F[Unit] = {
       underlyingConnection.sendMessage(m)
@@ -256,25 +266,32 @@ object ConnectionHandler {
   }
 
   object HandledConnection {
-    private[ConnectionHandler] def outgoing[F[_], K, M](
+    private[ConnectionHandler] def outgoing[F[_]: Concurrent, K, M](
         encryptedConnection: EncryptedConnection[F, K, M]
-    ): HandledConnection[F, K, M] = {
-      new HandledConnection(
-        encryptedConnection.remotePeerInfo._1,
-        encryptedConnection.remotePeerInfo._2,
-        encryptedConnection
-      ) {}
+    ): F[HandledConnection[F, K, M]] = {
+      Deferred[F, Unit].map { listener =>
+        new HandledConnection(
+          encryptedConnection.remotePeerInfo._1,
+          encryptedConnection.remotePeerInfo._2,
+          encryptedConnection,
+          listener
+        ) {}
+      }
     }
 
-    private[ConnectionHandler] def incoming[F[_], K, M](
+    private[ConnectionHandler] def incoming[F[_]: Concurrent, K, M](
         serverAddress: InetSocketAddress,
         encryptedConnection: EncryptedConnection[F, K, M]
-    ): HandledConnection[F, K, M] = {
-      new HandledConnection(
-        encryptedConnection.remotePeerInfo._1,
-        serverAddress,
-        encryptedConnection
-      ) {}
+    ): F[HandledConnection[F, K, M]] = {
+      Deferred[F, Unit].map { listener =>
+        new HandledConnection(
+          encryptedConnection.remotePeerInfo._1,
+          serverAddress,
+          encryptedConnection,
+          listener
+        ) {}
+      }
+
     }
 
   }

--- a/metronome/networking/src/io/iohk/metronome/networking/ConnectionsRegister.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/ConnectionsRegister.scala
@@ -23,6 +23,10 @@ class ConnectionsRegister[F[_]: Concurrent, K, M](
     }
   }
 
+  def registerConnection(connection: HandledConnection[F, K, M]): F[Unit] = {
+    registerRef.update(register => register + (connection.key -> connection))
+  }
+
   def isNewConnection(connectionKey: K): F[Boolean] = {
     registerRef.get.map(register => !register.contains(connectionKey))
   }

--- a/metronome/networking/src/io/iohk/metronome/networking/ConnectionsRegister.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/ConnectionsRegister.scala
@@ -23,10 +23,6 @@ class ConnectionsRegister[F[_]: Concurrent, K, M](
     }
   }
 
-  def registerConnection(connection: HandledConnection[F, K, M]): F[Unit] = {
-    registerRef.update(register => register + (connection.key -> connection))
-  }
-
   def isNewConnection(connectionKey: K): F[Boolean] = {
     registerRef.get.map(register => !register.contains(connectionKey))
   }
@@ -45,6 +41,16 @@ class ConnectionsRegister[F[_]: Concurrent, K, M](
       connectionKey: K
   ): F[Option[HandledConnection[F, K, M]]] =
     registerRef.get.map(register => register.get(connectionKey))
+
+  def replace(
+      connection: HandledConnection[F, K, M]
+  ): F[Option[HandledConnection[F, K, M]]] = {
+    registerRef.modify { register =>
+      register.updated(connection.key, connection) -> register.get(
+        connection.key
+      )
+    }
+  }
 
 }
 

--- a/metronome/networking/src/io/iohk/metronome/networking/RemoteConnectionManager.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/RemoteConnectionManager.scala
@@ -5,7 +5,7 @@ import cats.effect.implicits._
 import cats.effect.{Concurrent, ContextShift, Resource, Sync, Timer}
 import cats.implicits._
 import io.iohk.metronome.networking.ConnectionHandler.{
-  HandledConnection,
+  FinishedConnection,
   MessageReceived
 }
 import io.iohk.metronome.networking.RemoteConnectionManager.RetryConfig.RandomJitterConfig
@@ -190,9 +190,7 @@ object RemoteConnectionManager {
               updatedRequest => connectionsToAcquire.offer(updatedRequest)
             )
         case Right(connection) =>
-          val newOutgoingConnections =
-            HandledConnection.outgoing(connection.encryptedConnection)
-          connectionsHandler.registerOrClose(newOutgoingConnections)
+          connectionsHandler.registerOutgoing(connection.encryptedConnection)
 
       }
       .completedF
@@ -217,11 +215,10 @@ object RemoteConnectionManager {
           encryptedConnection.remotePeerInfo._1
         ) match {
           case Some(incomingConnectionServerAddress) =>
-            val handledConnection = HandledConnection.incoming(
+            connectionsHandler.registerIncoming(
               incomingConnectionServerAddress,
               encryptedConnection
             )
-            connectionsHandler.registerOrClose(handledConnection)
 
           case None =>
             // unknown connection, just close it
@@ -245,12 +242,12 @@ object RemoteConnectionManager {
       connectionsToAcquire: ConcurrentQueue[F, OutGoingConnectionRequest[K]],
       retryConfig: RetryConfig
   ) {
-    def finish(handledConnection: HandledConnection[F, K, M]): F[Unit] = {
+    def finish(finishedConnection: FinishedConnection[K]): F[Unit] = {
       retryConnection(
         retryConfig,
         OutGoingConnectionRequest.initial(
-          handledConnection.key,
-          handledConnection.serverAddress
+          finishedConnection.connectionKey,
+          finishedConnection.connectionServerAddress
         )
       ).flatMap(req => connectionsToAcquire.offer(req))
     }
@@ -331,7 +328,7 @@ object RemoteConnectionManager {
         retryConfig
       )
 
-      connectionsHandler <- ConnectionHandler.apply(
+      connectionsHandler <- ConnectionHandler.apply[F, K, M](
         // when each connection will finished it the callback will be called, and connection will be put to connections to acquire
         // queue
         handledConnectionFinisher.finish

--- a/metronome/networking/src/io/iohk/metronome/networking/RemoteConnectionManager.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/RemoteConnectionManager.scala
@@ -1,6 +1,5 @@
 package io.iohk.metronome.networking
 
-import cats.effect.concurrent.Deferred
 import cats.effect.implicits._
 import cats.effect.{Concurrent, ContextShift, Resource, Sync, Timer}
 import cats.implicits._
@@ -237,15 +236,6 @@ object RemoteConnectionManager {
       }
       .completedL
   }
-
-  def withCancelToken[F[_]: Concurrent, A](
-      token: Deferred[F, Unit],
-      ops: F[Option[A]]
-  ): F[Option[A]] =
-    Concurrent[F].race(token.get, ops).map {
-      case Left(()) => None
-      case Right(x) => x
-    }
 
   class HandledConnectionFinisher[F[_]: Concurrent: Timer, K, M](
       connectionsToAcquire: ConcurrentQueue[F, OutGoingConnectionRequest[K]],

--- a/metronome/networking/test/src/io/iohk/metronome/networking/ConnectionHandlerSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/ConnectionHandlerSpec.scala
@@ -1,29 +1,25 @@
 package io.iohk.metronome.networking
 
-import monix.execution.Scheduler
-import org.scalatest.flatspec.AsyncFlatSpecLike
-import org.scalatest.matchers.should.Matchers
-
-import scala.concurrent.duration._
-import RemoteConnectionManagerTestUtils._
 import cats.effect.Resource
 import cats.effect.concurrent.Deferred
 import io.iohk.metronome.networking.ConnectionHandler.{
   ConnectionAlreadyClosedException,
-  HandledConnection
+  FinishedConnection
 }
 import io.iohk.metronome.networking.ConnectionHandlerSpec.{
   buildHandlerResource,
   buildNConnections,
-  newHandledConnection
+  _
 }
-import io.iohk.metronome.networking.MockEncryptedConnectionProvider.MockEncryptedConnection
-import monix.eval.Task
-import ConnectionHandlerSpec._
 import io.iohk.metronome.networking.EncryptedConnectionProvider.DecodingError
-import io.iohk.metronome.networking.RemoteConnectionManagerWithMockProviderSpec.fakeLocalAddress
+import io.iohk.metronome.networking.MockEncryptedConnectionProvider.MockEncryptedConnection
+import io.iohk.metronome.networking.RemoteConnectionManagerTestUtils._
+import monix.eval.Task
+import monix.execution.Scheduler
+import org.scalatest.flatspec.AsyncFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import io.iohk.metronome.tracer.Tracer
-import java.net.InetSocketAddress
+import scala.concurrent.duration._
 
 class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
   implicit val testScheduler =
@@ -36,11 +32,11 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
     buildHandlerResource()
   ) { handler =>
     for {
-      handledConnection1 <- newHandledConnection()
-      _                  <- handler.registerOrClose(handledConnection1._1)
-      connections        <- handler.getAllActiveConnections
+      newConnection <- MockEncryptedConnection()
+      _             <- handler.registerOutgoing(newConnection)
+      connections   <- handler.getAllActiveConnections
     } yield {
-      assert(connections.contains(handledConnection1._1.key))
+      assert(connections.contains(newConnection.key))
     }
   }
 
@@ -48,12 +44,12 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
     buildHandlerResource()
   ) { handler =>
     for {
-      handledConnection1 <- newHandledConnection()
-      _                  <- handler.registerOrClose(handledConnection1._1)
-      connections        <- handler.getAllActiveConnections
-      sendResult         <- handler.sendMessage(handledConnection1._1.key, MessageA(1))
+      newConnection <- MockEncryptedConnection()
+      _             <- handler.registerOutgoing(newConnection)
+      connections   <- handler.getAllActiveConnections
+      sendResult    <- handler.sendMessage(newConnection.key, MessageA(1))
     } yield {
-      assert(connections.contains(handledConnection1._1.key))
+      assert(connections.contains(newConnection.key))
       assert(sendResult.isRight)
     }
   }
@@ -62,15 +58,15 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
     buildHandlerResource()
   ) { handler =>
     for {
-      handledConnection1 <- newHandledConnection()
-      connections        <- handler.getAllActiveConnections
-      sendResult         <- handler.sendMessage(handledConnection1._1.key, MessageA(1))
+      newConnection <- MockEncryptedConnection()
+      connections   <- handler.getAllActiveConnections
+      sendResult    <- handler.sendMessage(newConnection.key, MessageA(1))
     } yield {
       assert(connections.isEmpty)
       assert(sendResult.isLeft)
       assert(
         sendResult.left.getOrElse(null) == ConnectionAlreadyClosedException(
-          handledConnection1._1.key
+          newConnection.key
         )
       )
     }
@@ -80,18 +76,17 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
     buildHandlerResource()
   ) { handler =>
     for {
-      handledConnection1 <- newHandledConnection()
-      (handled, underLaying) = handledConnection1
-      _           <- underLaying.closeRemoteWithoutInfo
-      _           <- handler.registerOrClose(handledConnection1._1)
-      connections <- handler.getAllActiveConnections
-      sendResult  <- handler.sendMessage(handledConnection1._1.key, MessageA(1))
+      newConnection <- MockEncryptedConnection()
+      _             <- newConnection.closeRemoteWithoutInfo
+      _             <- handler.registerOutgoing(newConnection)
+      connections   <- handler.getAllActiveConnections
+      sendResult    <- handler.sendMessage(newConnection.key, MessageA(1))
     } yield {
-      assert(connections.contains(handledConnection1._1.key))
+      assert(connections.contains(newConnection.key))
       assert(sendResult.isLeft)
       assert(
         sendResult.left.getOrElse(null) == ConnectionAlreadyClosedException(
-          handledConnection1._1.key
+          newConnection.key
         )
       )
     }
@@ -101,19 +96,18 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
     buildHandlerResource()
   ) { handler =>
     for {
-      handledConnection <- newHandledConnection()
-      duplicatedConnection <- newHandledConnection(remotePeerInfo =
-        (handledConnection._1.key, handledConnection._1.serverAddress)
+      newConnection <- MockEncryptedConnection()
+      duplicatedConnection <- MockEncryptedConnection(
+        (newConnection.key, newConnection.address)
       )
-      (handled, underlyingEncrypted) = handledConnection
-      _                           <- handler.registerOrClose(handled)
+      _                           <- handler.registerOutgoing(newConnection)
       connections                 <- handler.getAllActiveConnections
-      _                           <- handler.registerOrClose(duplicatedConnection._1)
+      _                           <- handler.registerOutgoing(duplicatedConnection)
       connectionsAfterDuplication <- handler.getAllActiveConnections
-      closedAfterDuplication      <- duplicatedConnection._2.isClosed
+      closedAfterDuplication      <- duplicatedConnection.isClosed
     } yield {
-      assert(connections.contains(handled.key))
-      assert(connectionsAfterDuplication.contains(handled.key))
+      assert(connections.contains(newConnection.key))
+      assert(connectionsAfterDuplication.contains(newConnection.key))
       assert(closedAfterDuplication)
 
     }
@@ -126,7 +120,7 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
       (handler, release) = handlerAndRelease
       connections <- buildNConnections(expectedNumberOfConnections)
       _ <- Task.traverse(connections)(connection =>
-        handler.registerOrClose(connection._1)
+        handler.registerOutgoing(connection)
       )
       maxNumberOfActiveConnections <- handler.numberOfActiveConnections
         .waitFor(numOfConnections =>
@@ -148,11 +142,10 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
       cb                <- Deferred.tryable[Task, Unit]
       handlerAndRelease <- buildHandlerResource(_ => cb.complete(())).allocated
       (handler, release) = handlerAndRelease
-      connection <- newHandledConnection()
-      (handledConnection, underlyingEncrypted) = connection
-      _              <- handler.registerOrClose(handledConnection)
+      newConnection  <- MockEncryptedConnection()
+      _              <- handler.registerOutgoing(newConnection)
       numberOfActive <- handler.numberOfActiveConnections.waitFor(_ == 1)
-      _              <- underlyingEncrypted.pushRemoteEvent(None)
+      _              <- newConnection.pushRemoteEvent(None)
       numberOfActiveAfterDisconnect <- handler.numberOfActiveConnections
         .waitFor(_ == 0)
       callbackCompleted <- cb.tryGet.waitFor(_.isDefined)
@@ -169,11 +162,10 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
       cb                <- Deferred.tryable[Task, Unit]
       handlerAndRelease <- buildHandlerResource(_ => cb.complete(())).allocated
       (handler, release) = handlerAndRelease
-      connection <- newHandledConnection()
-      (handledConnection, underlyingEncrypted) = connection
-      _              <- handler.registerOrClose(handledConnection)
+      newConnection  <- MockEncryptedConnection()
+      _              <- handler.registerOutgoing(newConnection)
       numberOfActive <- handler.numberOfActiveConnections.waitFor(_ == 1)
-      _              <- underlyingEncrypted.pushRemoteEvent(Some(Left(DecodingError)))
+      _              <- newConnection.pushRemoteEvent(Some(Left(DecodingError)))
       numberOfActiveAfterError <- handler.numberOfActiveConnections
         .waitFor(_ == 0)
       callbackCompleted <- cb.tryGet.waitFor(_.isDefined)
@@ -190,9 +182,8 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
       cb                <- Deferred.tryable[Task, Unit]
       handlerAndRelease <- buildHandlerResource(_ => cb.complete(())).allocated
       (handler, release) = handlerAndRelease
-      connection <- newHandledConnection()
-      (handledConnection, underlyingEncrypted) = connection
-      _              <- handler.registerOrClose(handledConnection)
+      newConnection  <- MockEncryptedConnection()
+      _              <- handler.registerOutgoing(newConnection)
       numberOfActive <- handler.numberOfActiveConnections.waitFor(_ == 1)
       _              <- release
       numberOfActiveAfterDisconnect <- handler.numberOfActiveConnections
@@ -212,13 +203,13 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
     for {
       connections <- buildNConnections(expectedNumberOfConnections)
       _ <- Task.traverse(connections)(connection =>
-        handler.registerOrClose(connection._1)
+        handler.registerOutgoing(connection)
       )
       maxNumberOfActiveConnections <- handler.numberOfActiveConnections
         .waitFor(numOfConnections =>
           numOfConnections == expectedNumberOfConnections
         )
-      _ <- Task.traverse(connections) { case (_, encConnection) =>
+      _ <- Task.traverse(connections) { encConnection =>
         encConnection.pushRemoteEvent(Some(Right(MessageA(1))))
       }
       receivedMessages <- handler.incomingMessages
@@ -226,7 +217,7 @@ class ConnectionHandlerSpec extends AsyncFlatSpecLike with Matchers {
         .toListL
     } yield {
 
-      val senders      = connections.map(_._1.key).toSet
+      val senders      = connections.map(_.key).toSet
       val receivedFrom = receivedMessages.map(_.from).toSet
       assert(receivedMessages.size == expectedNumberOfConnections)
       assert(maxNumberOfActiveConnections == expectedNumberOfConnections)
@@ -249,38 +240,16 @@ object ConnectionHandlerSpec {
     NetworkTracers(Tracer.noOpTracer)
 
   def buildHandlerResource(
-      cb: HandledConnection[Task, Secp256k1Key, TestMessage] => Task[Unit] =
-        _ => Task(())
+      cb: FinishedConnection[Secp256k1Key] => Task[Unit] = _ => Task(())
   ): Resource[Task, ConnectionHandler[Task, Secp256k1Key, TestMessage]] = {
     ConnectionHandler
       .apply[Task, Secp256k1Key, TestMessage](cb)
   }
 
-  def newHandledConnection(
-      remotePeerInfo: (Secp256k1Key, InetSocketAddress) =
-        (Secp256k1Key.getFakeRandomKey, fakeLocalAddress)
-  )(implicit
-      s: Scheduler
-  ): Task[
-    (
-        HandledConnection[Task, Secp256k1Key, TestMessage],
-        MockEncryptedConnection
-    )
-  ] = {
-    for {
-      enc <- MockEncryptedConnection(remotePeerInfo)
-    } yield (HandledConnection.outgoing(enc), enc)
-  }
-
   def buildNConnections(n: Int)(implicit
       s: Scheduler
-  ): Task[List[
-    (
-        HandledConnection[Task, Secp256k1Key, TestMessage],
-        MockEncryptedConnection
-    )
-  ]] = {
-    Task.traverse((0 until n).toList)(_ => newHandledConnection())
+  ): Task[List[MockEncryptedConnection]] = {
+    Task.traverse((0 until n).toList)(_ => MockEncryptedConnection())
   }
 
 }

--- a/metronome/networking/test/src/io/iohk/metronome/networking/MockEncryptedConnectionProvider.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/MockEncryptedConnectionProvider.scala
@@ -245,6 +245,8 @@ object MockEncryptedConnectionProvider {
     ) {
       lazy val key = connection.remotePeerInfo._1
 
+      lazy val address = connection.remotePeerInfo._2
+
       def pushRemoteEvent(
           ev: Option[
             Either[EncryptedConnectionProvider.ConnectionError, TestMessage]


### PR DESCRIPTION
Add possibility to safely replace conflicting connections. Main use case for this feature is the case when, node is restarted after failure and what to reconnect to members in cluster who are not aware of it.

Main things done here:
- add more context info to `HandledConnection` which is now totally internal to `ConnectionHandler`
- different logic for handling conflicts in case of incoming and outgoing connections.

