### PR TITLE
PM-3104: Generic BlockStorage component for HotStuff

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -296,6 +296,7 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       override def moduleDeps: Seq[JavaModule] =
         Seq(
           tracing,
+          storage,
           hotstuff.service,
           checkpointing.models,
           checkpointing.interpreter

--- a/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/models/Block.scala
+++ b/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/models/Block.scala
@@ -22,6 +22,7 @@ sealed abstract case class Block private (
 }
 
 object Block {
+  type Hash = Block.Header.Hash
 
   /** Create a from a header and body we received from the network.
     *

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
@@ -1,0 +1,198 @@
+package io.iohk.metronome.checkpointing.service.storage
+
+import cats.implicits._
+import io.iohk.metronome.storage.{KVStore, KVCollection}
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, Block}
+import scala.collection.immutable.Queue
+
+/** Storage for blocks that maintains parent-child relationships as well,
+  * to facilitate tree traversal and pruning.
+  *
+  * It is assumed that the application maintains some pointers into the tree
+  * where it can start traversing from, e.g. the last Commit Quorum Certificate
+  * would point at a block hash which would serve as the entry point.
+  */
+class BlockStorage[N, A <: Agreement: Block](
+    blockColl: KVCollection[N, A#Hash, A#Block],
+    childToParentColl: KVCollection[N, A#Hash, A#Hash],
+    parentToChildrenColl: KVCollection[N, A#Hash, Set[A#Hash]]
+) {
+  implicit val kvn = KVStore.instance[N]
+
+  /** Insert a block into the store, and if the parent still exists,
+    * then add this block to its children.
+    */
+  def put(block: A#Block): KVStore[N, Unit] = {
+    val blockHash  = implicitly[Block[A]].blockHash(block)
+    val parentHash = implicitly[Block[A]].parentBlockHash(block)
+
+    blockColl.put(blockHash, block) >>
+      childToParentColl.put(blockHash, parentHash) >>
+      parentToChildrenColl.update(parentHash, _ + blockHash)
+  }
+
+  /** Retrieve a block by hash, if it exists. */
+  def get(blockHash: A#Hash): KVStore[N, Option[A#Block]] =
+    blockColl.get(blockHash)
+
+  /** Check whether a block is present in the tree. */
+  def contains(blockHash: A#Hash): KVStore[N, Boolean] =
+    childToParentColl.get(blockHash).map(_.isDefined)
+
+  /** Check how many children the block has in the tree. */
+  private def childCount(blockHash: A#Hash): KVStore[N, Int] =
+    parentToChildrenColl.get(blockHash).map(_.fold(0)(_.size))
+
+  /** Check whether the parent of the block is present in the tree. */
+  private def hasParent(blockHash: A#Hash): KVStore[N, Boolean] =
+    childToParentColl.get(blockHash).flatMap {
+      case None             => KVStore[N].pure(false)
+      case Some(parentHash) => contains(parentHash)
+    }
+
+  /** Check whether it's safe to delete a block.
+    *
+    * A block is safe to delete if doing so doesn't break up the tree
+    * into a forest, in which case we may have blocks we cannot reach
+    * by traversal, leaking space.
+    *
+    * This is true if the block has no children,
+    * or it has no parent and at most one child.
+    */
+  private def canDelete(blockHash: A#Hash): KVStore[N, Boolean] =
+    (hasParent(blockHash), childCount(blockHash)).mapN {
+      case (_, 0)     => true
+      case (false, 1) => true
+      case _          => false
+    }
+
+  /** Delete a block by hash, if doing so wouldn't break the tree;
+    * otherwise do nothing.
+    *
+    * Return `true` if block has been deleted, `false` if not.
+    *
+    * If this is not efficent enough, then move the deletion traversal
+    * logic into the this class so it can make sure all the invariants
+    * are maintained, e.g. collect all  hashes that can be safely deleted
+    * and then do so without checks.
+    */
+  def delete(blockHash: A#Hash): KVStore[N, Boolean] =
+    canDelete(blockHash).flatMap { ok =>
+      deleteUnsafe(blockHash).whenA(ok).as(ok)
+    }
+
+  /** Delete a block and remove it from any parent-to-child mapping,
+    * without any checking for the tree structure invariants.
+    */
+  private def deleteUnsafe(blockHash: A#Hash): KVStore[N, Unit] =
+    blockColl.delete(blockHash) >>
+      childToParentColl.get(blockHash).flatMap {
+        case None =>
+          KVStore[N].unit
+        case Some(parentHash) =>
+          childToParentColl.delete(blockHash) >>
+            parentToChildrenColl.update(parentHash, _ - blockHash)
+      }
+
+  /** Get the ancestor chain of a block from the root,
+    * including the block itself.
+    *
+    * If the block is not in the tree, the result will be empty,
+    * otherwise `head` will be the root of the block tree,
+    * and `last` will be the block itself.
+    */
+  def getPathFromRoot(blockHash: A#Hash): KVStore[N, List[A#Hash]] = {
+    def loop(
+        blockHash: A#Hash,
+        acc: List[A#Hash]
+    ): KVStore[N, List[A#Hash]] = {
+      childToParentColl.get(blockHash).flatMap {
+        case None =>
+          // This block doesn't exist in the tree, so our ancestry is whatever we collected so far.
+          KVStore[N].pure(acc)
+
+        case Some(parentHash) =>
+          // So at least `blockHash` exists in the tree.
+          loop(parentHash, blockHash :: acc)
+      }
+    }
+    loop(blockHash, Nil)
+  }
+
+  /** Get the ancestor chain of a block up to the root,
+    * excluding the block itself.
+    *
+    * If the block is not in the tree, the result will be empty,
+    * otherwise `head` will be the parent of the block,
+    * and `last` will be the root of block tree.
+    */
+  def getAncestors(blockHash: A#Hash): KVStore[N, List[A#Hash]] =
+    getPathFromRoot(blockHash) map {
+      case Nil  => Nil
+      case path => path.reverse.tail
+    }
+
+  /** Collect all descendants of a block.
+    *
+    * The result will start with the blocks furthest away,
+    * so it should be safe to delete them in the same order.
+    *
+    * The `skip` parameter can be used to avoid traversing
+    * branches that we want to keep during deletion.
+    */
+  def getDescendants(
+      blockHash: A#Hash,
+      skip: Set[A#Hash] = Set.empty
+  ): KVStore[N, List[A#Hash]] = {
+    // BFS traversal.
+    def loop(
+        queue: Queue[A#Hash],
+        acc: List[A#Hash]
+    ): KVStore[N, List[A#Hash]] = {
+      queue.dequeueOption match {
+        case None =>
+          KVStore[N].pure(acc)
+
+        case Some((blockHash, queue)) if skip(blockHash) =>
+          loop(queue, acc)
+
+        case Some((blockHash, queue)) =>
+          parentToChildrenColl.get(blockHash).flatMap {
+            case None =>
+              loop(queue, blockHash :: acc)
+            case Some(children) =>
+              loop(queue ++ children, blockHash :: acc)
+          }
+      }
+    }
+    loop(Queue(blockHash), Nil)
+  }
+
+  /** Delete all blocks which are not descendants of a given block,
+    * making it the new root.
+    *
+    * Return the list of deleted block hashes.
+    */
+  def pruneNonDescendants(blockHash: A#Hash): KVStore[N, List[A#Hash]] =
+    getPathFromRoot(blockHash).flatMap {
+      case Nil =>
+        KVStore[N].pure(Nil)
+
+      case path @ (rootHash :: _) =>
+        // The safe order to delete blocks would be to go down the main chain
+        // from the root, delete each non-mainchain child, then the parent,
+        // then descend on the main chain until we hit `blockHash`.
+
+        // A similar effect can be achieved by collecting all descendants
+        // of the root, then deleting everything that isn't on the main chain,
+        // from the children towards the root, and finally the main chain itself,
+        // going from the root towards the children.
+        val isMainChain = path.toSet
+
+        for {
+          deleteables <- getDescendants(rootHash, skip = Set(blockHash))
+          _           <- deleteables.filterNot(isMainChain).traverse(deleteUnsafe(_))
+          _           <- path.init.traverse(deleteUnsafe(_))
+        } yield deleteables
+    }
+}

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
@@ -1,4 +1,4 @@
-package io.iohk.metronome.checkpointing.service.storage
+package io.iohk.metronome.hotstuff.service.storage
 
 import cats.implicits._
 import io.iohk.metronome.storage.{KVStore, KVCollection}
@@ -17,7 +17,7 @@ class BlockStorage[N, A <: Agreement: Block](
     childToParentColl: KVCollection[N, A#Hash, A#Hash],
     parentToChildrenColl: KVCollection[N, A#Hash, Set[A#Hash]]
 ) {
-  implicit val kvn = KVStore.instance[N]
+  private implicit val kvn = KVStore.instance[N]
 
   /** Insert a block into the store, and if the parent still exists,
     * then add this block to its children.

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
@@ -57,14 +57,12 @@ object BlockStorageProps extends Properties("BlockStorage") {
     def containsBlock(blockHash: Hash) =
       TestKVStore
         .compile(TestBlockStorage.contains(blockHash))
-        .runA(store)
-        .value
+        .run(store)
 
     def getBlock(blockHash: Hash) =
       TestKVStore
         .compile(TestBlockStorage.get(blockHash))
-        .runA(store)
-        .value
+        .run(store)
 
     def deleteBlock(blockHash: Hash) =
       TestKVStore
@@ -75,14 +73,12 @@ object BlockStorageProps extends Properties("BlockStorage") {
     def getPathFromRoot(blockHash: Hash) =
       TestKVStore
         .compile(TestBlockStorage.getPathFromRoot(blockHash))
-        .runA(store)
-        .value
+        .run(store)
 
     def getDescendants(blockHash: Hash) =
       TestKVStore
         .compile(TestBlockStorage.getDescendants(blockHash))
-        .runA(store)
-        .value
+        .run(store)
 
     def pruneNonDescendants(blockHash: Hash) =
       TestKVStore

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
@@ -1,0 +1,107 @@
+package io.iohk.metronome.hotstuff.service.storage
+
+import cats.implicits._
+import io.iohk.metronome.storage.{KVCollection, KVStoreState}
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, Block => BlockOps}
+import java.util.UUID
+import org.scalacheck._
+import org.scalacheck.Prop.forAll
+import scodec.codecs.implicits._
+import scodec.Codec
+
+object BlockStorageProps extends Properties("BlockStorage") {
+
+  case class TestBlock(id: String, parentId: String) {
+    def isGenesis = parentId.isEmpty
+  }
+
+  object TestAggreement extends Agreement {
+    type Block = TestBlock
+    type Hash  = String
+    type PSig  = Nothing
+    type GSig  = Nothing
+    type PKey  = Nothing
+    type SKey  = Nothing
+
+    implicit val block = new BlockOps[TestAggreement] {
+      override def blockHash(b: TestBlock)       = b.id
+      override def parentBlockHash(b: TestBlock) = b.parentId
+    }
+  }
+  type TestAggreement = TestAggreement.type
+  type Hash           = TestAggreement.Hash
+
+  implicit def `Codec[Set[T]]`[T: Codec] =
+    implicitly[Codec[List[T]]].xmap[Set[T]](_.toSet, _.toList)
+
+  type Namespace = String
+  object Namespace {
+    val Blocks          = "blocks"
+    val BlockToParent   = "block-to-parent"
+    val BlockToChildren = "block-to-children"
+  }
+
+  object TestBlockStorage
+      extends BlockStorage[Namespace, TestAggreement](
+        new KVCollection[Namespace, Hash, TestBlock](Namespace.Blocks),
+        new KVCollection[Namespace, Hash, Hash](Namespace.BlockToParent),
+        new KVCollection[Namespace, Hash, Set[Hash]](Namespace.BlockToChildren)
+      )
+
+  object TestKVStore extends KVStoreState[Namespace]
+
+  def genBlockId: Gen[Hash] =
+    Gen.delay(UUID.randomUUID().toString)
+
+  /** Generate a block with a given parent, using the next available ID. */
+  def genBlock(parentId: Hash): Gen[TestBlock] =
+    genBlockId.map { uuid =>
+      TestBlock(uuid, parentId)
+    }
+
+  def genBlock: Gen[TestBlock] =
+    genBlockId.flatMap(genBlock)
+
+  /** Generate a (possibly empty) block tree. */
+  def genBlockTree(parentId: Hash): Gen[List[TestBlock]] =
+    for {
+      childCount <- Gen.frequency(
+        3 -> 0,
+        5 -> 1,
+        2 -> 2
+      )
+      children <- Gen.listOfN(
+        childCount, {
+          for {
+            block <- genBlock(parentId)
+            tree  <- genBlockTree(block.id)
+          } yield block +: tree
+        }
+      )
+    } yield children.flatten
+
+  /** Generate a block tree from a genesis block. */
+  def genBlockTree: Gen[List[TestBlock]] =
+    genBlockTree(parentId = "")
+
+  case class TestData(
+      tree: List[TestBlock],
+      store: TestKVStore.Store
+  )
+
+  /** Initialise a storage with a chain. */
+  def genTestData: Gen[TestData] =
+    genBlockTree.map { blocks =>
+      val insert = blocks.map(TestBlockStorage.put).sequence
+      val store  = TestKVStore.compile(insert).runS(Map.empty).value
+      TestData(blocks, store)
+    }
+
+  property("put") = forAll(genTestData, genBlock) { case (data, block) =>
+    val p = TestBlockStorage.put(block)
+    val s = TestKVStore.compile(p).runS(data.store).value
+
+    s(Namespace.Blocks)(block.id) == block
+    s(Namespace.BlockToParent)(block.id) == block.parentId
+  }
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreRead.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreRead.scala
@@ -10,10 +10,10 @@ import scodec.Codec
   */
 object KVStoreRead {
 
-  def unit[N]: KVStore[N, Unit] =
+  def unit[N]: KVStoreRead[N, Unit] =
     pure(())
 
-  def pure[N, A](a: A): KVStore[N, A] =
+  def pure[N, A](a: A): KVStoreRead[N, A] =
     Free.pure(a)
 
   def instance[N]: Ops[N] = new Ops[N] {}
@@ -25,9 +25,9 @@ object KVStoreRead {
 
     type KVNamespacedOp[A] = ({ type L[A] = KVStoreReadOp[N, A] })#L[A]
 
-    def unit: KVStore[N, Unit] = KVStore.unit[N]
+    def unit: KVStoreRead[N, Unit] = KVStoreRead.unit[N]
 
-    def pure[A](a: A) = KVStore.pure[N, A](a)
+    def pure[A](a: A) = KVStoreRead.pure[N, A](a)
 
     def read[K: Codec, V: Codec](
         namespace: N,

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreState.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreState.scala
@@ -74,6 +74,10 @@ class KVStoreState[N] {
   def compile[A](program: KVStore[N, A]): KVNamespacedState[A] =
     program.foldMap(stateCompiler)
 
+  /** Compile a KVStore program to a Reader monad, which can be executed like:
+    *
+    * `new KvStoreState[String].compile(program).run(Map.empty)`
+    */
   def compile[A](program: KVStoreRead[N, A]): KVNamespacedReader[A] =
     program.foldMap(readerCompiler)
 }


### PR DESCRIPTION
Created a `BlockStorage` component under `hotstuff.service` that stores anything that has a `hotstuff.consensus.basic.Block` type class. The component manages parent-child relationships and makes available some traversal methods that were useful in tentative branch management. 

Also supports a pruning method which can be used to get rid of any block that isn't a descendant of a given hash. This can be used for example to periodically walk up the main chain from the last committed block, and get rid of anything that isn't a descendant of a block that is the, say, the 100th ancestor of the last committed block:

```scala
def prune[F[_]: Sync](
  db: RocksDBStore[F], 
  blockStorage: BlockStorage[RocksDB.Namespace, CheckpointingAggreement], 
  commitQC: QuorumCertificate[CheckpointingAgreement],
  maxChainLength: Int
): F[Unit] = {
  val program: KVStore[RocksDB.Namespace, Unit] = 
    for {
      mainChain <- blockStorage.getPathFromRoot(commitQC.blockHash).lift
      maybeNewRoot = mainChain.dropRight(maxChainLength).headOption
      _ <- maybeNewRoot match {
        case None => KVStore[RocksDB.Namespace].unit
        case Some(newRoot) => blockStorage.pruneNonDescendants(newRoot).void
      }
    } yield ()

  db.runWithBatching(program)
}
```

I thought about wrapping blocks in some meta-data to track timestamps, but I'm hoping that pruning can be done based on just the volume of information, i.e. we can always assume that everyone has synced the last 100 blocks.
