### PR TITLE
PM-3104: Insert blocks in any order

### DIFF
--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
@@ -90,11 +90,7 @@ class BlockStorage[N, A <: Agreement: Block](
     */
   private def deleteUnsafe(blockHash: A#Hash): KVStore[N, Unit] = {
     def deleteIfEmpty(maybeChildren: Option[Set[A#Hash]]) =
-      maybeChildren match {
-        case None                               => None
-        case Some(children) if children.isEmpty => None
-        case children                           => children
-      }
+      maybeChildren.filter(_.nonEmpty)
 
     childToParentColl.get(blockHash).flatMap {
       case None =>

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
@@ -29,8 +29,13 @@ class BlockStorage[N, A <: Agreement: Block](
 
     blockColl.put(blockHash, block) >>
       childToParentColl.put(blockHash, parentHash) >>
-      parentToChildrenColl.put(blockHash, Set.empty) >>
-      parentToChildrenColl.update(parentHash)(_ + blockHash)
+      parentToChildrenColl.alter(blockHash) { maybeChildren =>
+        maybeChildren orElse Set.empty.some
+      } >>
+      parentToChildrenColl.alter(parentHash) { maybeChildren =>
+        maybeChildren orElse Set.empty.some map (_ + blockHash)
+      }
+
   }
 
   /** Retrieve a block by hash, if it exists. */

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
@@ -168,15 +168,12 @@ class BlockStorage[N, A <: Agreement: Block](
           }
       }
     }
-    loop(Queue(blockHash), Nil).flatMap { result =>
-      if (result.size == 1) {
-        contains(blockHash).map {
-          case true  => result
-          case false => Nil
-        }
-      } else {
+
+    loop(Queue(blockHash), Nil).flatMap {
+      case result @ List(`blockHash`) =>
+        result.filterA(contains)
+      case result =>
         KVStoreRead[N].pure(result)
-      }
     }
   }
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
@@ -30,7 +30,7 @@ class BlockStorage[N, A <: Agreement: Block](
     blockColl.put(blockHash, block) >>
       childToParentColl.put(blockHash, parentHash) >>
       parentToChildrenColl.put(blockHash, Set.empty) >>
-      parentToChildrenColl.update(parentHash, _ + blockHash)
+      parentToChildrenColl.update(parentHash)(_ + blockHash)
   }
 
   /** Retrieve a block by hash, if it exists. */
@@ -91,7 +91,7 @@ class BlockStorage[N, A <: Agreement: Block](
       case None =>
         KVStore[N].unit
       case Some(parentHash) =>
-        parentToChildrenColl.update(parentHash, _ - blockHash)
+        parentToChildrenColl.update(parentHash)(_ - blockHash)
     } >>
       blockColl.delete(blockHash) >>
       childToParentColl.delete(blockHash) >>

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
@@ -5,6 +5,7 @@ import io.iohk.metronome.storage.{KVCollection, KVStoreState}
 import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, Block => BlockOps}
 import java.util.UUID
 import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.{all, forAll, propBoolean}
 import scodec.codecs.implicits._
 import scodec.Codec
@@ -170,7 +171,8 @@ object BlockStorageProps extends Properties("BlockStorage") {
   property("put unordered") = forAll {
     for {
       ordered <- genNonEmptyBlockTree
-      unordered = Random.shuffle(ordered)
+      seed    <- arbitrary[Int]
+      unordered = new Random(seed).shuffle(ordered)
     } yield (ordered, unordered)
   } { case (ordered, unordered) =>
     val orderedStore   = TestKVStore.build(ordered)

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
@@ -211,6 +211,13 @@ object BlockStorageProps extends Properties("BlockStorage") {
       data.store.deleteBlock(nonExisting.id)._2 == true
   }
 
+  property("reinsert one") = forAll(genExisting) { case (data, existing) =>
+    val (deleted, _) = data.store.deleteBlock(existing.id)
+    val inserted     = deleted.putBlock(existing)
+    // The existing child relationships should not be lost.
+    inserted == data.store
+  }
+
   property("getPathFromRoot existing") = forAll(genExisting) {
     case (data, existing) =>
       val path = data.store.getPathFromRoot(existing.id)

--- a/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
@@ -32,10 +32,10 @@ class KVCollection[N, K: Codec, V: Codec](namespace: N) {
     KVStore[N].delete(namespace, key)
 
   /** Update a key by getting the value and applying a function on it, if the value exists. */
-  def update(key: K, f: V => V): KVStore[N, Unit] =
-    KVStore[N].update(namespace, key, f)
+  def update(key: K)(f: V => V): KVStore[N, Unit] =
+    KVStore[N].update(namespace, key)(f)
 
   /** Insert, update or delete a value, depending on whether it exists. */
-  def alter(key: K, f: Option[V] => Option[V]): KVStore[N, Unit] =
-    KVStore[N].alter(namespace, key, f)
+  def alter(key: K)(f: Option[V] => Option[V]): KVStore[N, Unit] =
+    KVStore[N].alter(namespace, key)(f)
 }

--- a/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVCollection.scala
@@ -34,4 +34,8 @@ class KVCollection[N, K: Codec, V: Codec](namespace: N) {
   /** Update a key by getting the value and applying a function on it, if the value exists. */
   def update(key: K, f: V => V): KVStore[N, Unit] =
     KVStore[N].update(namespace, key, f)
+
+  /** Insert, update or delete a value, depending on whether it exists. */
+  def alter(key: K, f: Option[V] => Option[V]): KVStore[N, Unit] =
+    KVStore[N].alter(namespace, key, f)
 }

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
@@ -57,10 +57,7 @@ object KVStore {
     def update[K: Codec, V: Codec](namespace: N, key: K)(
         f: V => V
     ): KVStore[N, Unit] =
-      get[K, V](namespace, key).flatMap {
-        case None        => unit
-        case Some(value) => put(namespace, key, f(value))
-      }
+      alter[K, V](namespace, key)(_ map f)
 
     /** Insert, update or delete a value, depending on whether it exists. */
     def alter[K: Codec, V: Codec](namespace: N, key: K)(

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
@@ -31,6 +31,7 @@ object KVStore {
 
     def pure[A](a: A) = KVStore.pure[N, A](a)
 
+    /** Insert or replace a value under a key. */
     def put[K: Codec, V: Codec](
         namespace: N,
         key: K,
@@ -40,16 +41,19 @@ object KVStore {
         Put[N, K, V](namespace, key, value)
       )
 
+    /** Get a value under a key, if it exists. */
     def get[K: Codec, V: Codec](namespace: N, key: K): KVStore[N, Option[V]] =
       liftF[KVNamespacedOp, Option[V]](
         Get[N, K, V](namespace, key)
       )
 
+    /** Delete a value under a key. */
     def delete[K: Codec](namespace: N, key: K): KVStore[N, Unit] =
       liftF[KVNamespacedOp, Unit](
         Delete[N, K](namespace, key)
       )
 
+    /** Apply a function on a value, if it exists. */
     def update[K: Codec, V: Codec](
         namespace: N,
         key: K,
@@ -58,6 +62,20 @@ object KVStore {
       get[K, V](namespace, key).flatMap {
         case None        => unit
         case Some(value) => put(namespace, key, f(value))
+      }
+
+    /** Insert, update or delete a value, depending on whether it exists. */
+    def alter[K: Codec, V: Codec](
+        namespace: N,
+        key: K,
+        f: Option[V] => Option[V]
+    ): KVStore[N, Unit] =
+      get[K, V](namespace, key).flatMap { current =>
+        (current, f(current)) match {
+          case (None, None)     => unit
+          case (_, Some(value)) => put(namespace, key, value)
+          case (Some(_), None)  => delete(namespace, key)
+        }
       }
 
     /** Lift a read-only operation into a read-write one, so that we can chain them together. */

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
@@ -68,9 +68,10 @@ object KVStore {
     ): KVStore[N, Unit] =
       get[K, V](namespace, key).flatMap { current =>
         (current, f(current)) match {
-          case (None, None)     => unit
-          case (_, Some(value)) => put(namespace, key, value)
-          case (Some(_), None)  => delete(namespace, key)
+          case ((None, None))                                       => unit
+          case ((Some(existing), Some(value))) if existing == value => unit
+          case (_, Some(value))                                     => put(namespace, key, value)
+          case (Some(_), None)                                      => delete(namespace, key)
         }
       }
 

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStore.scala
@@ -54,9 +54,7 @@ object KVStore {
       )
 
     /** Apply a function on a value, if it exists. */
-    def update[K: Codec, V: Codec](
-        namespace: N,
-        key: K,
+    def update[K: Codec, V: Codec](namespace: N, key: K)(
         f: V => V
     ): KVStore[N, Unit] =
       get[K, V](namespace, key).flatMap {
@@ -65,9 +63,7 @@ object KVStore {
       }
 
     /** Insert, update or delete a value, depending on whether it exists. */
-    def alter[K: Codec, V: Codec](
-        namespace: N,
-        key: K,
+    def alter[K: Codec, V: Codec](namespace: N, key: K)(
         f: Option[V] => Option[V]
     ): KVStore[N, Unit] =
       get[K, V](namespace, key).flatMap { current =>


### PR DESCRIPTION
Changes the `BlockStore` in anticipation of block synchronisation to be able to insert blocks in reverse, or any other order, and still maintain parent-child relationships. 

Currently if a child is inserted before its parent, then the parent-to-children association will not be populated, and traversal from ancestors towards descendants will not work. After the change, the parent-to-children association is established by the insertion of the children. The removal happens when the last child _and_ the parent are all removed. 

Added a `KVStore.alter` method (like `Data.Map.alter` in Haskell) to be able to insert/update/delete in one operation.

I expect that during block synchronisation we'll start walking the tree backwards until one of these conditions hold:
* we find a block we already have in storage
* we find a Commit Q.C. in which case we don't need the ancestry, so we can clear our block storage and re-insert from the new root

For the first case we'll insert blocks going from child to parent, and this change will ensure that during that we can still traverse the stored blocks in both ways. This is true for in-memory as well as persistent storage. 

NOTE: The `parentToChildrenColl` will no longer contain an empty set when a block is inserted, only when its first child is inserted. The reason for this was so that when we delete the last child in `deleteUnsafe` we can safely remove an empty Set; otherwise we'd have to check that the parent doesn't exist, which would incur yet another query. The only repercussion was that `getDescendants` has to check whether a single result is due to non-existent block or empty children.