### PR TITLE
PM-3112: ViewState persistence

### DIFF
--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -18,7 +18,10 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   QuorumCertificate
 }
 import io.iohk.metronome.hotstuff.service.pipes.BlockSyncPipe
-import io.iohk.metronome.hotstuff.service.storage.BlockStorage
+import io.iohk.metronome.hotstuff.service.storage.{
+  BlockStorage,
+  ViewStateStorage
+}
 import io.iohk.metronome.hotstuff.service.tracing.ConsensusTracers
 import io.iohk.metronome.networking.ConnectionHandler
 import io.iohk.metronome.storage.KVStoreRunner
@@ -35,6 +38,7 @@ class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
     publicKey: A#PKey,
     network: Network[F, A, Message[A]],
     blockStorage: BlockStorage[N, A],
+    viewStateStorage: ViewStateStorage[N, A],
     stateRef: Ref[F, ProtocolState[A]],
     stashRef: Ref[F, ConsensusService.MessageStash[A]],
     blockSyncPipe: BlockSyncPipe[F, A]#Left,
@@ -229,10 +233,39 @@ class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
       applySyncEffects(state, effects)
 
     // Unstash messages before we change state.
-    unstash(nextState) >>
+    captureChanges(nextState) >>
+      unstash(nextState) >>
       stateRef.set(nextState) >>
       scheduleEffects(nextEffects)
   }
+
+  /** Update the view state with and trace changes when they happen. */
+  private def captureChanges(nextState: ProtocolState[A]): F[Unit] = {
+    stateRef.get.flatMap { state =>
+      def ifChanged[T](get: ProtocolState[A] => T)(f: T => F[Unit]) = {
+        val prev = get(state)
+        val next = get(nextState)
+        f(next).whenA(prev != next)
+      }
+
+      ifChanged(_.viewNumber)(updateViewNumber) >>
+        ifChanged(_.prepareQC)(updateQuorum) >>
+        ifChanged(_.lockedQC)(updateQuorum) >>
+        ifChanged(_.commitQC)(updateQuorum)
+    }
+  }
+
+  private def updateViewNumber(viewNumber: ViewNumber): F[Unit] =
+    tracers.newView(viewNumber) >>
+      storeRunner.runReadWrite {
+        viewStateStorage.setViewNumber(viewNumber)
+      }
+
+  private def updateQuorum(quorumCertificate: QuorumCertificate[A]): F[Unit] =
+    tracers.quorum(quorumCertificate) >>
+      storeRunner.runReadWrite {
+        viewStateStorage.setQuorumCertificate(quorumCertificate)
+      }
 
   /** Requeue messages which arrived too early, but are now due becuase
     * the state caught up with them.
@@ -248,10 +281,7 @@ class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
 
       requeue.whenA(
         nextState.viewNumber != state.viewNumber || nextState.phase != state.phase
-      ) >>
-        tracers
-          .newView(nextState.viewNumber)
-          .whenA(nextState.viewNumber != state.viewNumber)
+      )
     }
 
   /** Carry out local effects before anything else,
@@ -357,8 +387,7 @@ class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
         // should be offloaded to another queue.
         //
         // Save the Commit Quorum Certificate to the view state.
-        saveCommitQC(commitQC) >>
-          blockExecutionQueue.offer(effect)
+        blockExecutionQueue.offer(effect)
 
       case SendMessage(recipient, message) =>
         network.sendMessage(recipient, message)
@@ -367,14 +396,6 @@ class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
     process.handleErrorWith { case NonFatal(ex) =>
       tracers.error(ex)
     }
-  }
-
-  /** Update the view state with the last Commit Quorum Certificate. */
-  private def saveCommitQC(qc: QuorumCertificate[A]): F[Unit] = {
-    assert(qc.phase == Phase.Commit)
-    tracers.quorum(qc)
-    // TODO (PM-3112): Persist View State.
-    ???
   }
 
   /** Execute blocks in order, updating pesistent storage along the way. */
@@ -453,6 +474,7 @@ object ConsensusService {
       publicKey: A#PKey,
       network: Network[F, A, Message[A]],
       blockStorage: BlockStorage[N, A],
+      viewStateStorage: ViewStateStorage[N, A],
       blockSyncPipe: BlockSyncPipe[F, A]#Left,
       initState: ProtocolState[A],
       maxEarlyViewNumberDiff: Int = 1
@@ -467,6 +489,7 @@ object ConsensusService {
           publicKey,
           network,
           blockStorage,
+          viewStateStorage,
           blockSyncPipe,
           initState,
           maxEarlyViewNumberDiff,
@@ -487,6 +510,7 @@ object ConsensusService {
       publicKey: A#PKey,
       network: Network[F, A, Message[A]],
       blockStorage: BlockStorage[N, A],
+      viewStateStorage: ViewStateStorage[N, A],
       blockSyncPipe: BlockSyncPipe[F, A]#Left,
       initState: ProtocolState[A],
       maxEarlyViewNumberDiff: Int,
@@ -507,6 +531,7 @@ object ConsensusService {
         publicKey,
         network,
         blockStorage,
+        viewStateStorage,
         stateRef,
         stashRef,
         blockSyncPipe,

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -385,8 +385,6 @@ class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
         // the forground here, but it may cause the node to lose its
         // sync with the other federation members, so the execution
         // should be offloaded to another queue.
-        //
-        // Save the Commit Quorum Certificate to the view state.
         blockExecutionQueue.offer(effect)
 
       case SendMessage(recipient, message) =>

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
@@ -12,7 +12,10 @@ import io.iohk.metronome.hotstuff.service.messages.{
   SyncMessage
 }
 import io.iohk.metronome.hotstuff.service.pipes.BlockSyncPipe
-import io.iohk.metronome.hotstuff.service.storage.BlockStorage
+import io.iohk.metronome.hotstuff.service.storage.{
+  BlockStorage,
+  ViewStateStorage
+}
 import io.iohk.metronome.hotstuff.service.tracing.{
   ConsensusTracers,
   SyncTracers
@@ -26,6 +29,7 @@ object HotStuffService {
       publicKey: A#PKey,
       network: Network[F, A, HotStuffMessage[A]],
       blockStorage: BlockStorage[N, A],
+      viewStateStorage: ViewStateStorage[N, A],
       initState: ProtocolState[A]
   )(implicit
       consensusTracers: ConsensusTracers[F, A],
@@ -53,6 +57,7 @@ object HotStuffService {
         publicKey,
         consensusNetwork,
         blockStorage,
+        viewStateStorage,
         blockSyncPipe.left,
         initState
       )

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
@@ -1,0 +1,72 @@
+package io.iohk.metronome.hotstuff.service.storage
+
+import io.iohk.metronome.hotstuff.consensus.ViewNumber
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
+import io.iohk.metronome.storage.KVStore
+import scodec.Codec
+
+/** Storing elements of the view state individually under separate keys,
+  * because they get written independently.
+  */
+class ViewStateStorage[N, A <: Agreement](namespace: N)(implicit
+    kvn: KVStore.Ops[N],
+    codecVN: Codec[ViewNumber],
+    codecQC: Codec[QuorumCertificate[A]],
+    codecH: Codec[A#Hash]
+) {}
+
+object ViewStateStorage {
+
+  sealed trait Key
+  object Key {
+    case object ViewNumber            extends Key
+    case object PrepareQC             extends Key
+    case object LockedQC              extends Key
+    case object CommitQC              extends Key
+    case object LastExecutedBlockHash extends Key
+  }
+
+  /** The state of consensus that needs to be persisted between restarts.
+    *
+    * The fields are a subset of the `ProtocolState` but have a slightly
+    * different life cylce, e.g. `lastExecutedBlockHash` is only updated
+    * when the blocks are actually executed, which happens asynchronously.
+    */
+  case class Bundle[A <: Agreement](
+      viewNumber: ViewNumber,
+      prepareQC: QuorumCertificate[A],
+      lockedQC: QuorumCertificate[A],
+      commitQC: QuorumCertificate[A],
+      lastExecutedBlockHash: A#Hash
+  )
+
+  /** Create a ViewStateStorage instance by pre-loading it with the genesis,
+    * unless it already has data.
+    */
+  def apply[N, A <: Agreement](
+      namespace: N,
+      genesisQC: QuorumCertificate[A]
+  )(implicit
+      codecVN: Codec[ViewNumber],
+      codecQC: Codec[QuorumCertificate[A]],
+      codecH: Codec[A#Hash]
+  ): KVStore[N, ViewStateStorage[N, A]] = {
+    implicit val kvn = KVStore.instance[N]
+
+    def setDefault[V](default: V): Option[V] => Option[V] =
+      (current: Option[V]) => current orElse Some(default)
+
+    for {
+      _ <- KVStore[N].alter(namespace, Key.ViewNumber)(
+        setDefault(genesisQC.viewNumber)
+      )
+      _ <- KVStore[N].alter(namespace, Key.PrepareQC)(setDefault(genesisQC))
+      _ <- KVStore[N].alter(namespace, Key.LockedQC)(setDefault(genesisQC))
+      _ <- KVStore[N].alter(namespace, Key.CommitQC)(setDefault(genesisQC))
+      _ <- KVStore[N].alter(namespace, Key.LastExecutedBlockHash)(
+        setDefault(genesisQC.blockHash)
+      )
+    } yield new ViewStateStorage[N, A](namespace)
+  }
+
+}

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
@@ -61,17 +61,16 @@ object ViewStateStorage {
     * because they get written independently.
     */
   trait Keys[A <: Agreement] {
-    sealed trait Key[V]
+    sealed abstract class Key[V](private val code: Int)
     object Key {
-      case object ViewNumber            extends Key[ViewNumber]
-      case object PrepareQC             extends Key[QuorumCertificate[A]]
-      case object LockedQC              extends Key[QuorumCertificate[A]]
-      case object CommitQC              extends Key[QuorumCertificate[A]]
-      case object LastExecutedBlockHash extends Key[A#Hash]
+      case object ViewNumber            extends Key[ViewNumber](0)
+      case object PrepareQC             extends Key[QuorumCertificate[A]](1)
+      case object LockedQC              extends Key[QuorumCertificate[A]](2)
+      case object CommitQC              extends Key[QuorumCertificate[A]](3)
+      case object LastExecutedBlockHash extends Key[A#Hash](4)
 
       implicit def encoder[V]: Encoder[Key[V]] =
-        scodec.codecs.implicits.implicitStringCodec
-          .contramap[Key[V]](_.toString)
+        scodec.codecs.uint8.contramap[Key[V]](_.code)
     }
   }
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
@@ -1,29 +1,78 @@
 package io.iohk.metronome.hotstuff.service.storage
 
+import cats.implicits._
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
-import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
-import io.iohk.metronome.storage.KVStore
-import scodec.Codec
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Agreement,
+  QuorumCertificate,
+  Phase
+}
+import io.iohk.metronome.storage.{KVStore, KVStoreRead}
+import scodec.{Codec, Encoder, Decoder}
 
-/** Storing elements of the view state individually under separate keys,
-  * because they get written independently.
-  */
-class ViewStateStorage[N, A <: Agreement](namespace: N)(implicit
+class ViewStateStorage[N, A <: Agreement] private (
+    namespace: N
+)(implicit
+    keys: ViewStateStorage.Keys[A],
     kvn: KVStore.Ops[N],
+    kvrn: KVStoreRead.Ops[N],
     codecVN: Codec[ViewNumber],
     codecQC: Codec[QuorumCertificate[A]],
     codecH: Codec[A#Hash]
-) {}
+) {
+  import keys.Key
+
+  private def put[V: Encoder](key: Key[V], value: V) =
+    KVStore[N].put[Key[V], V](namespace, key, value)
+
+  private def read[V: Decoder](key: Key[V]): KVStoreRead[N, V] =
+    KVStoreRead[N].read[Key[V], V](namespace, key).map(_.get)
+
+  def setViewNumber(viewNumber: ViewNumber): KVStore[N, Unit] =
+    put(Key.ViewNumber, viewNumber)
+
+  def setQuorumCertificate(qc: QuorumCertificate[A]): KVStore[N, Unit] =
+    qc.phase match {
+      case Phase.Prepare =>
+        put(Key.PrepareQC, qc)
+      case Phase.PreCommit =>
+        put(Key.LockedQC, qc)
+      case Phase.Commit =>
+        put(Key.CommitQC, qc)
+    }
+
+  def setLastExecutedBlockHash(blockHash: A#Hash): KVStore[N, Unit] =
+    put(Key.LastExecutedBlockHash, blockHash)
+
+  def getBundle: KVStoreRead[N, ViewStateStorage.Bundle[A]] =
+    (
+      read(Key.ViewNumber),
+      read(Key.PrepareQC),
+      read(Key.LockedQC),
+      read(Key.CommitQC),
+      read(Key.LastExecutedBlockHash)
+    ).mapN(ViewStateStorage.Bundle.apply[A] _)
+
+}
 
 object ViewStateStorage {
 
-  sealed trait Key
-  object Key {
-    case object ViewNumber            extends Key
-    case object PrepareQC             extends Key
-    case object LockedQC              extends Key
-    case object CommitQC              extends Key
-    case object LastExecutedBlockHash extends Key
+  /** Storing elements of the view state individually under separate keys,
+    * because they get written independently.
+    */
+  trait Keys[A <: Agreement] {
+    sealed trait Key[V]
+    object Key {
+      case object ViewNumber            extends Key[ViewNumber]
+      case object PrepareQC             extends Key[QuorumCertificate[A]]
+      case object LockedQC              extends Key[QuorumCertificate[A]]
+      case object CommitQC              extends Key[QuorumCertificate[A]]
+      case object LastExecutedBlockHash extends Key[A#Hash]
+
+      implicit def encoder[V]: Encoder[Key[V]] =
+        scodec.codecs.implicits.implicitStringCodec
+          .contramap[Key[V]](_.toString)
+    }
   }
 
   /** The state of consensus that needs to be persisted between restarts.
@@ -51,7 +100,10 @@ object ViewStateStorage {
       codecQC: Codec[QuorumCertificate[A]],
       codecH: Codec[A#Hash]
   ): KVStore[N, ViewStateStorage[N, A]] = {
-    implicit val kvn = KVStore.instance[N]
+    implicit val kvn  = KVStore.instance[N]
+    implicit val kvrn = KVStoreRead.instance[N]
+    implicit val keys = new Keys[A] {}
+    import keys.Key
 
     def setDefault[V](default: V): Option[V] => Option[V] =
       (current: Option[V]) => current orElse Some(default)

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorageProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorageProps.scala
@@ -1,0 +1,193 @@
+package io.iohk.metronome.hotstuff.service.storage
+
+import io.iohk.metronome.hotstuff.consensus.ViewNumber
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  QuorumCertificate,
+  Phase,
+  Agreement
+}
+import scala.annotation.nowarn
+import io.iohk.metronome.crypto.GroupSignature
+import io.iohk.metronome.storage.{KVStore, KVStoreRead, KVStoreState}
+import org.scalacheck.{Gen, Prop, Properties}
+import org.scalacheck.commands.Commands
+import org.scalacheck.Arbitrary.arbitrary
+import scala.util.Try
+import scodec.bits.BitVector
+import scodec.Codec
+import scala.util.Success
+
+object ViewStateStorageProps extends Properties("ViewStateStorage") {
+  property("commands") = ViewStateStorageCommands.property()
+}
+
+object ViewStateStorageCommands extends Commands {
+  object TestAggreement extends Agreement {
+    type Block = Nothing
+    type Hash  = String
+    type PSig  = Unit
+    type GSig  = List[String]
+    type PKey  = Nothing
+    type SKey  = Nothing
+  }
+  type TestAggreement = TestAggreement.type
+
+  type Namespace = String
+
+  object TestKVStoreState extends KVStoreState[Namespace]
+
+  type TestViewStateStorage = ViewStateStorage[Namespace, TestAggreement]
+
+  class StorageWrapper(
+      viewStateStorage: TestViewStateStorage,
+      private var store: TestKVStoreState.Store
+  ) {
+    def getStore = store
+
+    def write(
+        f: TestViewStateStorage => KVStore[Namespace, Unit]
+    ): Unit = {
+      store = TestKVStoreState.compile(f(viewStateStorage)).runS(store).value
+    }
+
+    def read[A](
+        f: TestViewStateStorage => KVStoreRead[Namespace, A]
+    ): A = {
+      TestKVStoreState.compile(f(viewStateStorage)).run(store)
+    }
+  }
+
+  type State = ViewStateStorage.Bundle[TestAggreement]
+  type Sut   = StorageWrapper
+
+  val genesisState = ViewStateStorage.Bundle
+    .fromGenesisQC[TestAggreement] {
+      QuorumCertificate[TestAggreement](
+        Phase.Prepare,
+        ViewNumber(1),
+        "",
+        GroupSignature(Nil)
+      )
+    }
+
+  /** The in-memory KVStoreState doesn't invoke the codecs. */
+  implicit def neverUsedCodec[T] =
+    Codec[T](
+      (_: T) => sys.error("Didn't expect to encode."),
+      (_: BitVector) => sys.error("Didn't expect to decode.")
+    )
+
+  @nowarn
+  override def canCreateNewSut(
+      newState: State,
+      initSuts: Traversable[State],
+      runningSuts: Traversable[Sut]
+  ): Boolean = true
+
+  override def initialPreCondition(state: State): Boolean =
+    state == genesisState
+
+  override def newSut(state: State): Sut = {
+    val init = TestKVStoreState.compile(
+      ViewStateStorage[Namespace, TestAggreement]("test-namespace", state)
+    )
+    val (store, storage) = init.run(Map.empty).value
+    new StorageWrapper(storage, store)
+  }
+
+  override def destroySut(sut: Sut): Unit = ()
+
+  override def genInitialState: Gen[State] = Gen.const(genesisState)
+
+  override def genCommand(state: State): Gen[Command] =
+    Gen.oneOf(
+      genSetViewNumber(state),
+      genSetQuorumCertificate(state),
+      genSetLastExecutedBlockHash(state),
+      genGetBundle
+    )
+
+  def genSetViewNumber(state: State) =
+    for {
+      d <- Gen.posNum[Long]
+      vn = ViewNumber(state.viewNumber + d)
+    } yield SetViewNumberCommand(vn)
+
+  def genSetQuorumCertificate(state: State) =
+    for {
+      p <- Gen.oneOf(Phase.Prepare, Phase.PreCommit, Phase.Commit)
+      h <- arbitrary[TestAggreement.Hash]
+      s <- arbitrary[TestAggreement.GSig]
+      qc = QuorumCertificate[TestAggreement](
+        p,
+        state.viewNumber,
+        h,
+        GroupSignature(s)
+      )
+    } yield SetQuorumCertificateCommand(qc)
+
+  def genSetLastExecutedBlockHash(state: State) =
+    for {
+      h <- Gen.oneOf(
+        state.prepareQC.blockHash,
+        state.lockedQC.blockHash,
+        state.commitQC.blockHash
+      )
+    } yield SetLastExecutedBlockHashCommand(h)
+
+  val genGetBundle = Gen.const(GetBundleCommand)
+
+  case class SetViewNumberCommand(viewNumber: ViewNumber) extends UnitCommand {
+    override def run(sut: Sut): Result =
+      sut.write(_.setViewNumber(viewNumber))
+    override def nextState(state: State): State =
+      state.copy(viewNumber = viewNumber)
+    override def preCondition(state: State): Boolean =
+      state.viewNumber < viewNumber
+    override def postCondition(state: State, success: Boolean): Prop = success
+  }
+
+  case class SetQuorumCertificateCommand(qc: QuorumCertificate[TestAggreement])
+      extends UnitCommand {
+    override def run(sut: Sut): Result =
+      sut.write(_.setQuorumCertificate(qc))
+
+    override def nextState(state: State): State =
+      qc.phase match {
+        case Phase.Prepare   => state.copy(prepareQC = qc)
+        case Phase.PreCommit => state.copy(lockedQC = qc)
+        case Phase.Commit    => state.copy(commitQC = qc)
+      }
+
+    override def preCondition(state: State): Boolean =
+      state.viewNumber <= qc.viewNumber
+
+    override def postCondition(state: State, success: Boolean): Prop = success
+  }
+
+  case class SetLastExecutedBlockHashCommand(blockHash: TestAggreement.Hash)
+      extends UnitCommand {
+    override def run(sut: Sut): Result =
+      sut.write(_.setLastExecutedBlockHash(blockHash))
+
+    override def nextState(state: State): State =
+      state.copy(lastExecutedBlockHash = blockHash)
+
+    override def preCondition(state: State): Boolean =
+      Set(state.prepareQC, state.lockedQC, state.commitQC)
+        .map(_.blockHash)
+        .contains(blockHash)
+
+    override def postCondition(state: State, success: Boolean): Prop = success
+  }
+
+  case object GetBundleCommand extends Command {
+    type Result = ViewStateStorage.Bundle[TestAggreement]
+
+    override def run(sut: Sut): Result               = sut.read(_.getBundle)
+    override def nextState(state: State): State      = state
+    override def preCondition(state: State): Boolean = true
+    override def postCondition(state: State, result: Try[Result]): Prop =
+      result == Success(state)
+  }
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreOp.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreOp.scala
@@ -1,6 +1,6 @@
 package io.iohk.metronome.storage
 
-import scodec.Codec
+import scodec.{Encoder, Decoder}
 
 /** Representing key-value storage operations as a Free Monad,
   * so that we can pick an execution strategy that best fits
@@ -20,15 +20,16 @@ sealed trait KVStoreWriteOp[N, A] extends KVStoreOp[N, A]
 
 object KVStoreOp {
   case class Put[N, K, V](namespace: N, key: K, value: V)(implicit
-      val keyCodec: Codec[K],
-      val valueCodec: Codec[V]
+      val keyEncoder: Encoder[K],
+      val valueEncoder: Encoder[V]
   ) extends KVStoreWriteOp[N, Unit]
 
   case class Get[N, K, V](namespace: N, key: K)(implicit
-      val keyCodec: Codec[K],
-      val valueCodec: Codec[V]
+      val keyEncoder: Encoder[K],
+      val valueDecoder: Decoder[V]
   ) extends KVStoreReadOp[N, Option[V]]
 
-  case class Delete[N, K](namespace: N, key: K)(implicit val keyCodec: Codec[K])
-      extends KVStoreWriteOp[N, Unit]
+  case class Delete[N, K](namespace: N, key: K)(implicit
+      val keyEncoder: Encoder[K]
+  ) extends KVStoreWriteOp[N, Unit]
 }

--- a/metronome/storage/src/io/iohk/metronome/storage/KVStoreRead.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVStoreRead.scala
@@ -2,7 +2,7 @@ package io.iohk.metronome.storage
 
 import cats.free.Free
 import cats.free.Free.liftF
-import scodec.Codec
+import scodec.{Encoder, Decoder}
 
 /** Helper methods to compose operations that strictly only do reads, no writes.
   *
@@ -29,7 +29,7 @@ object KVStoreRead {
 
     def pure[A](a: A) = KVStoreRead.pure[N, A](a)
 
-    def read[K: Codec, V: Codec](
+    def read[K: Encoder, V: Decoder](
         namespace: N,
         key: K
     ): KVStoreRead[N, Option[V]] =


### PR DESCRIPTION
Adds a `ViewStateStorage` component to store pieces of the `ProtocolState` that should survive a restart. These are the view number, the prepare/locked/commit Q.C., and the last executed block. At least I couldn't think of anything else now. (Actually there's one more thing: the root of the block tree, but I'll add that in the block synchronisation story; it will be used for pruning blocks when we can skip ahead to a new committed state without syncing blocks in between. EDIT: Added in https://github.com/input-output-hk/metronome/pull/37).

The storage is initialised by the genesis data, so it always has something to return. All items are stored under different keys, because they change at different points in time, and this way we don't have to retrieve some data, update it, then save it back, just do a single write. 

I expect that reads will happen only at startup, to initialise the `ProtocolState`, so instead of a stand-alone `ViewState` model, the reads return a `ViewStateStorage.Bundle` which is just a technical class to hold all fields together.

Also modified the `KVStore` classes to not require a `Codec` for keys since they are never decoded.