### PR TITLE
PM-3134: Block synchronisation

### DIFF
--- a/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/CheckpointingAgreement.scala
+++ b/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/CheckpointingAgreement.scala
@@ -1,6 +1,7 @@
 package io.iohk.metronome.checkpointing
 
 import io.iohk.metronome.crypto
+import io.iohk.metronome.hotstuff.consensus
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
 import io.iohk.metronome.hotstuff.consensus.basic.{
   Secp256k1Agreement,
@@ -27,4 +28,14 @@ object CheckpointingAgreement extends Secp256k1Agreement {
         rlp.encode(phase) ++ rlp.encode(viewNumber) ++ rlp.encode(hash)
       )
     )
+
+  implicit val block: consensus.basic.Block[CheckpointingAgreement] =
+    new consensus.basic.Block[CheckpointingAgreement] {
+      override def blockHash(b: models.Block) =
+        b.hash
+      override def parentBlockHash(b: models.Block) =
+        b.header.parentHash
+      override def isValid(b: models.Block) =
+        models.Block.isValid(b)
+    }
 }

--- a/metronome/core/src/io/iohk/metronome/core/Pipe.scala
+++ b/metronome/core/src/io/iohk/metronome/core/Pipe.scala
@@ -6,8 +6,8 @@ import monix.tail.Iterant
 import monix.catnap.ConcurrentQueue
 
 /** A `Pipe` is a connection between two components where
-  * messages of type `L` are going from left to right, and
-  * message of type `R` are going from right to left.
+  * messages of type `L` are going from left to right and
+  * messages of type `R` are going from right to left.
   */
 trait Pipe[F[_], L, R] {
   type Left  = Pipe.Side[F, L, R]

--- a/metronome/core/src/io/iohk/metronome/core/fibers/DeferredTask.scala
+++ b/metronome/core/src/io/iohk/metronome/core/fibers/DeferredTask.scala
@@ -4,12 +4,14 @@ import cats.implicits._
 import cats.effect.Sync
 import cats.effect.concurrent.Deferred
 import cats.effect.Concurrent
+import scala.util.control.NoStackTrace
 
 /** A task that can be executed on a fiber pool, or canceled if the pool is shut down.. */
 protected[fibers] class DeferredTask[F[_]: Sync, A](
     deferred: Deferred[F, Either[Throwable, A]],
     task: F[A]
 ) {
+  import DeferredTask.CanceledException
 
   /** Execute the task and set the success/failure result on the deferred. */
   def execute: F[Unit] =
@@ -19,15 +21,19 @@ protected[fibers] class DeferredTask[F[_]: Sync, A](
   def join: F[A] =
     deferred.get.rethrow
 
-  /** Signal to the submitter that the pool has been shut down. */
-  def shutdown: F[Unit] =
+  /** Signal to the submitter that this task is canceled. */
+  def cancel: F[Unit] =
     deferred
-      .complete(Left(new RuntimeException("The pool has been shut down.")))
+      .complete(Left(new CanceledException))
       .attempt
       .void
 }
 
 object DeferredTask {
+  class CanceledException
+      extends RuntimeException("This task has been canceled.")
+      with NoStackTrace
+
   def apply[F[_]: Concurrent, A](task: F[A]): F[DeferredTask[F, A]] =
     Deferred[F, Either[Throwable, A]].map { d =>
       new DeferredTask[F, A](d, task)

--- a/metronome/core/src/io/iohk/metronome/core/fibers/FiberSet.scala
+++ b/metronome/core/src/io/iohk/metronome/core/fibers/FiberSet.scala
@@ -52,7 +52,7 @@ class FiberSet[F[_]: Concurrent](
     fibers <- fibersRef.get
     _      <- fibers.toList.traverse(_.cancel)
     tasks  <- tasksRef.get
-    _      <- tasks.toList.traverse(_.shutdown)
+    _      <- tasks.toList.traverse(_.cancel)
   } yield ()
 }
 

--- a/metronome/core/src/io/iohk/metronome/core/messages/RPCMessage.scala
+++ b/metronome/core/src/io/iohk/metronome/core/messages/RPCMessage.scala
@@ -20,4 +20,16 @@ abstract class RPCMessageCompanion {
 
   trait Request  extends RPCMessage
   trait Response extends RPCMessage
+
+  def pair[A <: Request, B <: Response]: RPCPair.Aux[A, B] =
+    new RPCPair[A] { type Response = B }
+}
+
+trait RPCPair[Request] {
+  type Response
+}
+object RPCPair {
+  type Aux[A, B] = RPCPair[A] {
+    type Response = B
+  }
 }

--- a/metronome/core/src/io/iohk/metronome/core/messages/RPCMessage.scala
+++ b/metronome/core/src/io/iohk/metronome/core/messages/RPCMessage.scala
@@ -1,5 +1,6 @@
 package io.iohk.metronome.core.messages
 
+import cats.effect.Sync
 import java.util.UUID
 
 /** Messages that go in request/response pairs. */
@@ -13,18 +14,30 @@ trait RPCMessage {
 
 abstract class RPCMessageCompanion {
   type RequestId = UUID
+
   object RequestId {
     def apply(): RequestId =
       UUID.randomUUID()
+
+    def apply[F[_]: Sync]: F[RequestId] =
+      Sync[F].delay(apply())
   }
 
   trait Request  extends RPCMessage
   trait Response extends RPCMessage
 
+  /** Establish a relationship between a request and a response
+    * type so the compiler can infer the return value of methods
+    * based on the request parameter, or validate that two generic
+    * parameters belong with each other.
+    */
   def pair[A <: Request, B <: Response]: RPCPair.Aux[A, B] =
     new RPCPair[A] { type Response = B }
 }
 
+/** A request can be associated with at most one response type.
+  * On the other hand a response type can serve multiple requests.
+  */
 trait RPCPair[Request] {
   type Response
 }

--- a/metronome/core/src/io/iohk/metronome/core/messages/RPCTracker.scala
+++ b/metronome/core/src/io/iohk/metronome/core/messages/RPCTracker.scala
@@ -1,0 +1,89 @@
+package io.iohk.metronome.core.messages
+
+import cats.implicits._
+import cats.effect.{Concurrent, Timer, Sync}
+import cats.effect.concurrent.{Ref, Deferred}
+import java.util.UUID
+import scala.concurrent.duration.FiniteDuration
+import scala.reflect.ClassTag
+
+/** `RPCTracker` can be used to register outgoing requests and later
+  * match them up with incoming responses, thus turning the two independent
+  * messages into a `Kleisli[F, Request, Option[Response]]`, where a `None`
+  * result means the request timed out.
+  */
+class RPCTracker[F[_]: Timer: Concurrent, M](
+    deferredMapRef: Ref[F, Map[UUID, RPCTracker.Entry[F, _]]],
+    defaultTimeout: FiniteDuration
+) {
+  import RPCTracker.Entry
+
+  def register[
+      Req <: RPCMessageCompanion#Request,
+      Res <: RPCMessageCompanion#Response
+  ](
+      request: Req,
+      timeout: FiniteDuration = defaultTimeout
+  )(implicit
+      ev1: Req <:< M,
+      ev2: RPCPair.Aux[Req, Res],
+      ct: ClassTag[Res]
+  ): F[F[Option[Res]]] = {
+    val requestId = request.requestId
+    for {
+      d <- Deferred[F, Option[Res]]
+      e = RPCTracker.Entry(d)
+      _ <- deferredMapRef.update(_ + (requestId -> e))
+      _ <- Concurrent[F].start {
+        Timer[F].sleep(timeout) >> completeWithTimeout(requestId)
+      }
+    } yield d.get
+  }
+
+  def complete[Res <: RPCMessageCompanion#Response](
+      response: Res
+  )(implicit ev: Res <:< M): F[Boolean] = {
+    remove(response.requestId).flatMap {
+      case None    => false.pure[F]
+      case Some(e) => e.complete(response)
+    }
+  }
+
+  private def completeWithTimeout(requestId: UUID): F[Unit] =
+    remove(requestId).flatMap {
+      case None    => ().pure[F]
+      case Some(e) => e.timeout
+    }
+
+  private def remove(requestId: UUID): F[Option[Entry[F, _]]] =
+    deferredMapRef.modify { dm =>
+      (dm - requestId, dm.get(requestId))
+    }
+}
+
+object RPCTracker {
+  case class Entry[F[_]: Sync, Res](
+      deferred: Deferred[F, Option[Res]]
+  )(implicit ct: ClassTag[Res]) {
+    def timeout: F[Unit] =
+      deferred.complete(None).attempt.void
+
+    def complete[M](response: M): F[Boolean] = {
+      response match {
+        case expected: Res =>
+          deferred.complete(Some(expected)).attempt.map(_.isRight)
+        case _ =>
+          // Not returning an error because if the message arrived after
+          // the timeout we wouldn't know anyway what it was meant to complete.
+          false.pure[F]
+      }
+    }
+  }
+
+  def apply[F[_]: Concurrent: Timer, M](
+      defaultTimeout: FiniteDuration
+  ): F[RPCTracker[F, M]] =
+    Ref[F].of(Map.empty[UUID, Entry[F, _]]).map {
+      new RPCTracker(_, defaultTimeout)
+    }
+}

--- a/metronome/core/test/src/io/iohk/metronome/core/fibers/FiberSetSpec.scala
+++ b/metronome/core/test/src/io/iohk/metronome/core/fibers/FiberSetSpec.scala
@@ -39,8 +39,7 @@ class FiberSetSpec extends AsyncFlatSpec with Matchers with Inside {
         r <- r.attempt
       } yield {
         inside(r) { case Left(ex) =>
-          ex shouldBe a[RuntimeException]
-          ex.getMessage should include("shut down")
+          ex shouldBe a[DeferredTask.CanceledException]
         }
       }
     }

--- a/metronome/core/test/src/io/iohk/metronome/core/messages/RPCTrackerSpec.scala
+++ b/metronome/core/test/src/io/iohk/metronome/core/messages/RPCTrackerSpec.scala
@@ -1,0 +1,78 @@
+package io.iohk.metronome.core.messages
+
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.compatible.Assertion
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class RPCTrackerSpec extends AsyncFlatSpec with Matchers {
+
+  sealed trait TestMessage extends RPCMessage
+  object TestMessage extends RPCMessageCompanion {
+    case class FooRequest(requestId: RequestId) extends TestMessage with Request
+    case class FooResponse(requestId: RequestId, value: Int)
+        extends TestMessage
+        with Response
+    case class BarRequest(requestId: RequestId) extends TestMessage with Request
+    case class BarResponse(requestId: RequestId, value: String)
+        extends TestMessage
+        with Response
+
+    implicit val foo = pair[FooRequest, FooResponse]
+    implicit val bar = pair[BarRequest, BarResponse]
+  }
+  import TestMessage._
+
+  def test(
+      f: RPCTracker[Task, TestMessage] => Task[Assertion]
+  ): Future[Assertion] =
+    RPCTracker[Task, TestMessage](10.seconds)
+      .flatMap(f)
+      .timeout(5.seconds)
+      .runToFuture
+
+  behavior of "RPCTracker"
+
+  it should "complete responses within the timeout" in test { tracker =>
+    val req = FooRequest(RequestId())
+    val res = FooResponse(req.requestId, 1)
+    for {
+      join <- tracker.register(req)
+      ok   <- tracker.complete(res)
+      got  <- join
+    } yield {
+      ok shouldBe true
+      got shouldBe Some(res)
+    }
+  }
+
+  it should "complete responses with None after the timeout" in test {
+    tracker =>
+      val req = FooRequest(RequestId())
+      for {
+        join <- tracker.register(req, timeout = 50.millis)
+        _    <- Task.sleep(100.millis)
+        got  <- join
+      } yield {
+        got shouldBe empty
+      }
+  }
+
+  it should "complete responses with None if the wrong type of response arrives" in test {
+    tracker =>
+      val req = FooRequest(RequestId())
+      val res = BarResponse(RequestId(), "one")
+      for {
+        join <- tracker.register(req, timeout = 50.millis)
+        ok   <- tracker.complete(res)
+        got  <- join
+      } yield {
+        ok shouldBe false
+        got shouldBe empty
+      }
+  }
+
+}

--- a/metronome/core/test/src/io/iohk/metronome/core/messages/RPCTrackerSpec.scala
+++ b/metronome/core/test/src/io/iohk/metronome/core/messages/RPCTrackerSpec.scala
@@ -63,10 +63,11 @@ class RPCTrackerSpec extends AsyncFlatSpec with Matchers {
 
   it should "complete responses with None if the wrong type of response arrives" in test {
     tracker =>
-      val req = FooRequest(RequestId())
-      val res = BarResponse(RequestId(), "one")
       for {
-        join <- tracker.register(req, timeout = 50.millis)
+        rid <- RequestId[Task]
+        req = FooRequest(rid)
+        res = BarResponse(rid, "one")
+        join <- tracker.register(req)
         ok   <- tracker.complete(res)
         got  <- join
       } yield {

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Block.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Block.scala
@@ -12,6 +12,9 @@ package io.iohk.metronome.hotstuff.consensus.basic
 trait Block[A <: Agreement] {
   def blockHash(b: A#Block): A#Hash
   def parentBlockHash(b: A#Block): A#Hash
+
+  /** Perform simple content validation. */
+  def isValid(b: A#Block): Boolean
 }
 
 object Block {

--- a/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/HotStuffProtocolProps.scala
+++ b/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/HotStuffProtocolProps.scala
@@ -52,6 +52,7 @@ object HotStuffProtocolCommands extends Commands {
   implicit val block: Block[TestAgreement] = new Block[TestAgreement] {
     override def blockHash(b: TestBlock)       = b.blockHash
     override def parentBlockHash(b: TestBlock) = b.parentBlockHash
+    override def isValid(b: TestBlock)         = true
   }
 
   implicit val leaderSelection = LeaderSelection.Hashing

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -165,7 +165,7 @@ class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
       BlockSyncPipe.Request(sender, prepare)
     )
 
-  /** Process the synchronization. result queue. */
+  /** Process the synchronization result queue. */
   private def processBlockSyncPipe: F[Unit] =
     blockSyncPipe.receive
       .mapEval[Unit] { case BlockSyncPipe.Response(request, isValid) =>

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
@@ -26,7 +26,6 @@ object HotStuffService {
 
   /** Start up the HotStuff service stack. */
   def apply[F[_]: Concurrent: ContextShift: Timer, N, A <: Agreement: Block](
-      publicKey: A#PKey,
       network: Network[F, A, HotStuffMessage[A]],
       blockStorage: BlockStorage[N, A],
       viewStateStorage: ViewStateStorage[N, A],
@@ -54,7 +53,7 @@ object HotStuffService {
       blockSyncPipe <- Resource.liftF { BlockSyncPipe[F, A] }
 
       consensusService <- ConsensusService(
-        publicKey,
+        initState.publicKey,
         consensusNetwork,
         blockStorage,
         viewStateStorage,
@@ -63,6 +62,8 @@ object HotStuffService {
       )
 
       syncService <- SyncService(
+        initState.publicKey,
+        initState.federation,
         syncNetwork,
         blockStorage,
         blockSyncPipe.right,

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -4,7 +4,11 @@ import cats.implicits._
 import cats.effect.{Sync, Resource, Concurrent, ContextShift, Timer}
 import io.iohk.metronome.core.fibers.FiberMap
 import io.iohk.metronome.core.messages.RPCTracker
-import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, ProtocolState}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Agreement,
+  ProtocolState,
+  Block
+}
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 import io.iohk.metronome.hotstuff.service.pipes.BlockSyncPipe
 import io.iohk.metronome.hotstuff.service.storage.BlockStorage
@@ -159,7 +163,7 @@ object SyncService {
     * in the background, shutting processing down when the resource is
     * released.
     */
-  def apply[F[_]: Concurrent: ContextShift: Timer, N, A <: Agreement](
+  def apply[F[_]: Concurrent: ContextShift: Timer, N, A <: Agreement: Block](
       network: Network[F, A, SyncMessage[A]],
       blockStorage: BlockStorage[N, A],
       blockSyncPipe: BlockSyncPipe[F, A]#Right,

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -192,10 +192,8 @@ object SyncService {
         fiberSet,
         rpcTracker
       )
-      blockSync <- Resource.liftF {
-        BlockSynchronizer[F, N, A](blockStorage, service.getBlock)
-      }
-      _ <- Concurrent[F].background(service.processNetworkMessages)
-      _ <- Concurrent[F].background(service.processBlockSyncPipe(blockSync))
+      blockSync <- BlockSynchronizer[F, N, A](blockStorage, service.getBlock)
+      _         <- Concurrent[F].background(service.processNetworkMessages)
+      _         <- Concurrent[F].background(service.processBlockSyncPipe(blockSync))
     } yield service
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -138,8 +138,11 @@ class SyncService[F[_]: Sync, N, A <: Agreement](
           }
 
       case response: SyncMessage.Response =>
-        rpcTracker.complete(response).flatMap { ok =>
-          tracers.responseIgnored(from -> response).whenA(!ok)
+        rpcTracker.complete(response).flatMap {
+          case Right(ok) =>
+            tracers.responseIgnored((from, response, None)).whenA(!ok)
+          case Left(ex) =>
+            tracers.responseIgnored((from, response, Some(ex)))
         }
     }
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -47,14 +47,20 @@ class SyncService[F[_]: Sync, N, A <: Agreement](
 
   /** Request a block from a peer. */
   private def getBlock(from: A#PKey, blockHash: A#Hash): F[Option[A#Block]] = {
-    val request = GetBlockRequest(RequestId(), blockHash)
-    sendRequest(from, request) map (_.map(_.block))
+    for {
+      requestId <- RequestId[F]
+      request = GetBlockRequest(requestId, blockHash)
+      maybeResponse <- sendRequest(from, request)
+    } yield maybeResponse.map(_.block)
   }
 
   /** Request the status of a peer. */
   private def getStatus(from: A#PKey): F[Option[Status[A]]] = {
-    val request = GetStatusRequest[A](RequestId())
-    sendRequest(from, request) map (_.map(_.status))
+    for {
+      requestId <- RequestId[F]
+      request = GetStatusRequest[A](requestId)
+      maybeResponse <- sendRequest(from, request)
+    } yield maybeResponse.map(_.status)
   }
 
   /** Send a request to the peer and track the response.

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -50,6 +50,7 @@ class SyncService[F[_]: Sync, N, A <: Agreement](
       join <- rpcTracker.register(request)
       _    <- network.sendMessage(from, request)
       res  <- join
+      _    <- tracers.requestTimeout(from -> request).whenA(res.isEmpty)
     } yield res.map(_.block)
   }
 
@@ -63,6 +64,7 @@ class SyncService[F[_]: Sync, N, A <: Agreement](
       join <- rpcTracker.register(request)
       _    <- network.sendMessage(from, request)
       res  <- join
+      _    <- tracers.requestTimeout(from -> request).whenA(res.isEmpty)
     } yield res.map(_.status)
   }
 
@@ -122,7 +124,7 @@ class SyncService[F[_]: Sync, N, A <: Agreement](
 
       case response: SyncMessage.Response =>
         rpcTracker.complete(response).flatMap { ok =>
-          tracers.responseIgnored(response).whenA(!ok)
+          tracers.responseIgnored(from -> response).whenA(!ok)
         }
     }
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -148,7 +148,7 @@ class SyncService[F[_]: Sync, N, A <: Agreement](
         // If the same leader is sending us newer proposals, we can ignore the
         // previous pepared blocks - they are either part of the new Q.C.,
         // in which case they don't need to be validated, or they have not
-        // gathered enough votes, and been superceeded by a new proposal.
+        // gathered enough votes, and been superseded by a new proposal.
         syncFiberMap.cancelQueue(sender) >>
           syncFiberMap
             .submit(sender) {
@@ -201,8 +201,10 @@ object SyncService {
         syncFiberMap,
         rpcTracker
       )
-      blockSync <- BlockSynchronizer[F, N, A](blockStorage, service.getBlock)
-      _         <- Concurrent[F].background(service.processNetworkMessages)
-      _         <- Concurrent[F].background(service.processBlockSyncPipe(blockSync))
+      blockSync <- Resource.liftF {
+        BlockSynchronizer[F, N, A](blockStorage, service.getBlock)
+      }
+      _ <- Concurrent[F].background(service.processNetworkMessages)
+      _ <- Concurrent[F].background(service.processBlockSyncPipe(blockSync))
     } yield service
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/messages/SyncMessage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/messages/SyncMessage.scala
@@ -10,9 +10,9 @@ import io.iohk.metronome.hotstuff.service.Status
 sealed trait SyncMessage[+A <: Agreement] { self: RPCMessage => }
 
 object SyncMessage extends RPCMessageCompanion {
-  case class GetStatusRequest(
+  case class GetStatusRequest[A <: Agreement](
       requestId: RequestId
-  ) extends SyncMessage[Nothing]
+  ) extends SyncMessage[A]
       with Request
 
   case class GetStatusResponse[A <: Agreement](
@@ -32,4 +32,10 @@ object SyncMessage extends RPCMessageCompanion {
       block: A#Block
   ) extends SyncMessage[A]
       with Response
+
+  implicit def getBlockPair[A <: Agreement] =
+    pair[GetBlockRequest[A], GetBlockResponse[A]]
+
+  implicit def getStatusPair[A <: Agreement] =
+    pair[GetStatusRequest[A], GetStatusResponse[A]]
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
@@ -88,7 +88,7 @@ class BlockStorage[N, A <: Agreement: Block](
   /** Delete a block and remove it from any parent-to-child mapping,
     * without any checking for the tree structure invariants.
     */
-  private def deleteUnsafe(blockHash: A#Hash): KVStore[N, Unit] = {
+  def deleteUnsafe(blockHash: A#Hash): KVStore[N, Unit] = {
     def deleteIfEmpty(maybeChildren: Option[Set[A#Hash]]) =
       maybeChildren.filter(_.nonEmpty)
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
@@ -24,8 +24,8 @@ class BlockStorage[N, A <: Agreement: Block](
     * then add this block to its children.
     */
   def put(block: A#Block): KVStore[N, Unit] = {
-    val blockHash  = implicitly[Block[A]].blockHash(block)
-    val parentHash = implicitly[Block[A]].parentBlockHash(block)
+    val blockHash  = Block[A].blockHash(block)
+    val parentHash = Block[A].parentBlockHash(block)
 
     blockColl.put(blockHash, block) >>
       childToParentColl.put(blockHash, parentHash) >>

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
@@ -1,0 +1,81 @@
+package io.iohk.metronome.hotstuff.service.sync
+
+import cats.implicits._
+import cats.effect.{Resource, Sync}
+import cats.effect.concurrent.Ref
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
+import io.iohk.metronome.hotstuff.service.storage.BlockStorage
+import io.iohk.metronome.storage.{KVStoreRunner, KVStoreState}
+
+/** The job of the `BlockSynchronizer` is to procure missing blocks when a `Prepare`
+  * message builds on a High Q.C. that we don't have.
+  *
+  * It will walk backwards, asking for the ancestors until we find one that we already
+  * have in persistent storage, then append blocks to the storage in the opposite order.
+  *
+  * Since the final block has a Quorum Certificate, there's no need to validate the
+  * ancestors, assuming an honest majority in the federation. The only validation we
+  * need to do is hash checks to make sure we're getting the correct blocks.
+  *
+  * The synchronizer keeps the tentative blocks in memory until they can be connected
+  * to the persistent storage. We assume that we never have to download the block history
+  * back until genesis, but rather that the application will always have support for
+  * syncing to any given block and its associated state, to catch up after spending
+  * a long time offline. Once that happens the block history should be pruneable.
+  */
+class BlockSynchronizer[F[_]: Sync, N, A <: Agreement](
+    blockStorage: BlockStorage[N, A],
+    getBlock: BlockSynchronizer.GetBlock[F, A],
+    inMemoryStoreRef: Ref[F, KVStoreState[N]#Store]
+)(implicit storeRunner: KVStoreRunner[F, N]) {
+
+  // In memory KVStore query compiler.
+  val state = new KVStoreState[N]
+
+  /** Download all blocks up to the one included in the Quorum Certificate. */
+  def sync(
+      sender: A#PKey,
+      quorumCertificate: QuorumCertificate[A]
+  ): F[Unit] = {
+    // TODO (PM-3134): Block sync.
+
+    // We must take care not to insert blocks into storage and risk losing
+    // the pointer to them in a restart. Maybe keep the unfinished tree
+    // in memory until we find a parent we do have in storage, then
+    // insert them in the opposite order, validating against the application side
+    // as we go along, finally responding to the requestor.
+    storeRunner
+      .runReadOnly {
+        blockStorage.contains(quorumCertificate.blockHash)
+      }
+      .flatMap {
+        case true  => ().pure[F]
+        case false => ??? // TODO: Manage downloads.
+      }
+  }
+
+}
+
+object BlockSynchronizer {
+
+  /** Send a network request to get a block. */
+  type GetBlock[F[_], A <: Agreement] = (A#PKey, A#Hash) => F[Option[A#Block]]
+
+  /** Create a block synchronizer resource. Stop any background downloads when released. */
+  def apply[F[_]: Sync, N, A <: Agreement](
+      blockStorage: BlockStorage[N, A],
+      getBlock: GetBlock[F, A]
+  )(implicit
+      storeRunner: KVStoreRunner[F, N]
+  ): Resource[F, BlockSynchronizer[F, N, A]] =
+    Resource.liftF {
+      for {
+        inMemoryStoreRef <- Ref.of[F, KVStoreState[N]#Store](Map.empty)
+        synchronizer = new BlockSynchronizer[F, N, A](
+          blockStorage,
+          getBlock,
+          inMemoryStoreRef
+        )
+      } yield synchronizer
+    }
+}

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
@@ -100,7 +100,6 @@ class BlockSynchronizer[F[_]: Sync: Timer, N, A <: Agreement: Block](
                       } >> downloadParent(from, block, path)
 
                     case None =>
-                      // TODO: Trace.
                       Timer[F].sleep(retryTimeout) >>
                         download(from, blockHash, path)
                   }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
@@ -134,7 +134,7 @@ class BlockSynchronizer[F[_]: Sync: Timer, N, A <: Agreement: Block](
     * which indicates the blocks that no concurrent download has persisted yet,
     * then persist the rest.
     *
-    * Only doing oine persist operation at a time to make sure there's no competition
+    * Only doing oinepersist operation at a time to make sure there's no competition
     * in the insertion order of the path elements among concurrent downloads.
     */
   private def persist(

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
@@ -164,15 +164,13 @@ object BlockSynchronizer {
       getBlock: GetBlock[F, A]
   )(implicit
       storeRunner: KVStoreRunner[F, N]
-  ): Resource[F, BlockSynchronizer[F, N, A]] =
-    Resource.liftF {
-      for {
-        inMemoryStoreRef <- Ref.of[F, KVStoreState[N]#Store](Map.empty)
-        synchronizer = new BlockSynchronizer[F, N, A](
-          blockStorage,
-          getBlock,
-          inMemoryStoreRef
-        )
-      } yield synchronizer
-    }
+  ): F[BlockSynchronizer[F, N, A]] =
+    for {
+      inMemoryStoreRef <- Ref.of[F, KVStoreState[N]#Store](Map.empty)
+      synchronizer = new BlockSynchronizer[F, N, A](
+        blockStorage,
+        getBlock,
+        inMemoryStoreRef
+      )
+    } yield synchronizer
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
@@ -1,11 +1,21 @@
 package io.iohk.metronome.hotstuff.service.sync
 
 import cats.implicits._
-import cats.effect.{Resource, Sync}
+import cats.effect.{Resource, Sync, Timer}
 import cats.effect.concurrent.Ref
-import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Agreement,
+  QuorumCertificate,
+  Block
+}
 import io.iohk.metronome.hotstuff.service.storage.BlockStorage
-import io.iohk.metronome.storage.{KVStoreRunner, KVStoreState}
+import io.iohk.metronome.storage.{
+  KVStoreRunner,
+  KVStoreState,
+  KVStore,
+  KVStoreRead
+}
+import scala.concurrent.duration._
 
 /** The job of the `BlockSynchronizer` is to procure missing blocks when a `Prepare`
   * message builds on a High Q.C. that we don't have.
@@ -23,10 +33,11 @@ import io.iohk.metronome.storage.{KVStoreRunner, KVStoreState}
   * syncing to any given block and its associated state, to catch up after spending
   * a long time offline. Once that happens the block history should be pruneable.
   */
-class BlockSynchronizer[F[_]: Sync, N, A <: Agreement](
+class BlockSynchronizer[F[_]: Sync: Timer, N, A <: Agreement: Block](
     blockStorage: BlockStorage[N, A],
     getBlock: BlockSynchronizer.GetBlock[F, A],
-    inMemoryStoreRef: Ref[F, KVStoreState[N]#Store]
+    inMemoryStoreRef: Ref[F, KVStoreState[N]#Store],
+    retryTimeout: FiniteDuration = 5.seconds
 )(implicit storeRunner: KVStoreRunner[F, N]) {
 
   // In memory KVStore query compiler.
@@ -36,24 +47,105 @@ class BlockSynchronizer[F[_]: Sync, N, A <: Agreement](
   def sync(
       sender: A#PKey,
       quorumCertificate: QuorumCertificate[A]
-  ): F[Unit] = {
-    // TODO (PM-3134): Block sync.
+  ): F[Unit] =
+    sync(sender, quorumCertificate.blockHash, Nil)
 
-    // We must take care not to insert blocks into storage and risk losing
-    // the pointer to them in a restart. Maybe keep the unfinished tree
-    // in memory until we find a parent we do have in storage, then
-    // insert them in the opposite order, validating against the application side
-    // as we go along, finally responding to the requestor.
+  // We must take care not to insert blocks into storage and risk losing
+  // the pointer to them in a restart, hence keeping the unfinished tree
+  // in memory until we find a parent we do have in storage, then
+  // insert them in the opposite order.
+  private def sync(
+      sender: A#PKey,
+      blockHash: A#Hash,
+      path: List[A#Hash]
+  ): F[Unit] = {
     storeRunner
       .runReadOnly {
-        blockStorage.contains(quorumCertificate.blockHash)
+        blockStorage.contains(blockHash)
       }
       .flatMap {
-        case true  => ().pure[F]
-        case false => ??? // TODO: Manage downloads.
+        case true =>
+          persist(path)
+
+        case false =>
+          readInMemory {
+            blockStorage.get(blockHash)
+          }.flatMap {
+            case Some(block) =>
+              syncParent(sender, block, path)
+
+            case None =>
+              tryDownload(sender, blockHash)
+                .flatMap {
+                  case Some(block) =>
+                    writeInMemory {
+                      blockStorage.put(block)
+                    } >> syncParent(sender, block, path)
+
+                  case None =>
+                    Timer[F].sleep(retryTimeout) >>
+                      sync(sender, blockHash, path)
+                }
+          }
       }
   }
 
+  private def syncParent(
+      from: A#PKey,
+      block: A#Block,
+      path: List[A#Hash]
+  ): F[Unit] = {
+    val blockHash       = Block[A].blockHash(block)
+    val parentBlockHash = Block[A].parentBlockHash(block)
+    sync(from, parentBlockHash, blockHash :: path)
+  }
+
+  private def tryDownload(
+      from: A#PKey,
+      blockHash: A#Hash
+  ): F[Option[A#Block]] =
+    getBlock(from, blockHash).map(validateBlock(blockHash))
+
+  private def validateBlock(requestedBlockHash: A#Hash)(
+      maybeDownloadedBlock: Option[A#Block]
+  ): Option[A#Block] =
+    maybeDownloadedBlock.filter { block =>
+      Block[A].blockHash(block) == requestedBlockHash
+    }
+
+  /** Move the blocks on the path from memory to persistent storage. */
+  private def persist(
+      path: List[A#Hash]
+  ): F[Unit] =
+    path match {
+      case Nil =>
+        ().pure[F]
+
+      case blockHash :: rest =>
+        readInMemory {
+          blockStorage.get(blockHash)
+        } flatMap {
+          case None =>
+            // Another download has already persisted it.
+            persist(rest)
+
+          case Some(block) =>
+            storeRunner.runReadWrite {
+              blockStorage.put(block)
+            } >>
+              writeInMemory {
+                blockStorage.delete(blockHash).void
+              }
+        }
+    }
+
+  private def readInMemory[A](query: KVStoreRead[N, A]): F[A] =
+    inMemoryStoreRef.get.map(state.compile(query).run)
+
+  private def writeInMemory[A](query: KVStore[N, A]): F[A] =
+    inMemoryStoreRef.modify { store =>
+      state.compile(query).run(store).value
+    }
 }
 
 object BlockSynchronizer {
@@ -62,7 +154,7 @@ object BlockSynchronizer {
   type GetBlock[F[_], A <: Agreement] = (A#PKey, A#Hash) => F[Option[A#Block]]
 
   /** Create a block synchronizer resource. Stop any background downloads when released. */
-  def apply[F[_]: Sync, N, A <: Agreement](
+  def apply[F[_]: Sync: Timer, N, A <: Agreement: Block](
       blockStorage: BlockStorage[N, A],
       getBlock: GetBlock[F, A]
   )(implicit

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -23,7 +23,8 @@ object SyncEvent {
     */
   case class ResponseIgnored[A <: Agreement](
       sender: A#PKey,
-      response: SyncMessage[A] with SyncMessage.Response
+      response: SyncMessage[A] with SyncMessage.Response,
+      maybeError: Option[Throwable]
   ) extends SyncEvent[A]
 
   /** An unexpected error in one of the background tasks. */

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -8,12 +8,21 @@ sealed trait SyncEvent[+A <: Agreement]
 object SyncEvent {
 
   /** A federation member is sending us so many requests that its work queue is full. */
-  case class QueueFull[A <: Agreement](publicKey: A#PKey) extends SyncEvent[A]
+  case class QueueFull[A <: Agreement](
+      sender: A#PKey
+  ) extends SyncEvent[A]
+
+  /** A request we sent couldn't be matched with a response in time. */
+  case class RequestTimeout[A <: Agreement](
+      recipient: A#PKey,
+      request: SyncMessage[A] with SyncMessage.Request
+  ) extends SyncEvent[A]
 
   /** A response was ignored either because the request ID didn't match, or it already timed out,
     * or the response type didn't match the expected one based on the request.
     */
   case class ResponseIgnored[A <: Agreement](
+      sender: A#PKey,
       response: SyncMessage[A] with SyncMessage.Response
   ) extends SyncEvent[A]
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -1,6 +1,7 @@
 package io.iohk.metronome.hotstuff.service.tracing
 
 import io.iohk.metronome.hotstuff.consensus.basic.Agreement
+import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 
 sealed trait SyncEvent[+A <: Agreement]
 
@@ -8,6 +9,13 @@ object SyncEvent {
 
   /** A federation member is sending us so many requests that its work queue is full. */
   case class QueueFull[A <: Agreement](publicKey: A#PKey) extends SyncEvent[A]
+
+  /** A response was ignored either because the request ID didn't match, or it already timed out,
+    * or the response type didn't match the expected one based on the request.
+    */
+  case class ResponseIgnored[A <: Agreement](
+      response: SyncMessage[A] with SyncMessage.Response
+  ) extends SyncEvent[A]
 
   /** An unexpected error in one of the background tasks. */
   case class Error(error: Throwable) extends SyncEvent[Nothing]

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
@@ -3,9 +3,11 @@ package io.iohk.metronome.hotstuff.service.tracing
 import cats.implicits._
 import io.iohk.metronome.tracer.Tracer
 import io.iohk.metronome.hotstuff.consensus.basic.Agreement
+import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 
 case class SyncTracers[F[_], A <: Agreement](
     queueFull: Tracer[F, A#PKey],
+    responseIgnored: Tracer[F, SyncMessage[A] with SyncMessage.Response],
     error: Tracer[F, Throwable]
 )
 
@@ -17,6 +19,10 @@ object SyncTracers {
   ): SyncTracers[F, A] =
     SyncTracers[F, A](
       queueFull = tracer.contramap[A#PKey](QueueFull(_)),
+      responseIgnored = tracer
+        .contramap[SyncMessage[A] with SyncMessage.Response](
+          ResponseIgnored(_)
+        ),
       error = tracer.contramap[Throwable](Error(_))
     )
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
@@ -7,22 +7,33 @@ import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 
 case class SyncTracers[F[_], A <: Agreement](
     queueFull: Tracer[F, A#PKey],
-    responseIgnored: Tracer[F, SyncMessage[A] with SyncMessage.Response],
+    requestTimeout: Tracer[F, SyncTracers.Request[A]],
+    responseIgnored: Tracer[F, SyncTracers.Response[A]],
     error: Tracer[F, Throwable]
 )
 
 object SyncTracers {
   import SyncEvent._
 
+  type Request[A <: Agreement] =
+    (A#PKey, SyncMessage[A] with SyncMessage.Request)
+
+  type Response[A <: Agreement] =
+    (A#PKey, SyncMessage[A] with SyncMessage.Response)
+
   def apply[F[_], A <: Agreement](
       tracer: Tracer[F, SyncEvent[A]]
   ): SyncTracers[F, A] =
     SyncTracers[F, A](
       queueFull = tracer.contramap[A#PKey](QueueFull(_)),
+      requestTimeout = tracer
+        .contramap[Request[A]] { case (recipient, request) =>
+          RequestTimeout(recipient, request)
+        },
       responseIgnored = tracer
-        .contramap[SyncMessage[A] with SyncMessage.Response](
-          ResponseIgnored(_)
-        ),
+        .contramap[Response[A]] { case (sender, response) =>
+          ResponseIgnored(sender, response)
+        },
       error = tracer.contramap[Throwable](Error(_))
     )
 }

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
@@ -3,7 +3,6 @@ package io.iohk.metronome.hotstuff.service.storage
 import cats.implicits._
 import io.iohk.metronome.storage.{KVCollection, KVStoreState}
 import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, Block => BlockOps}
-import java.util.UUID
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.{all, forAll, propBoolean}
@@ -17,22 +16,22 @@ object BlockStorageProps extends Properties("BlockStorage") {
     def isGenesis = parentId.isEmpty
   }
 
-  object TestAggreement extends Agreement {
+  object TestAgreement extends Agreement {
     type Block = TestBlock
     type Hash  = String
     type PSig  = Nothing
-    type GSig  = Nothing
-    type PKey  = Nothing
+    type GSig  = Unit
+    type PKey  = Int
     type SKey  = Nothing
 
-    implicit val block = new BlockOps[TestAggreement] {
+    implicit val block = new BlockOps[TestAgreement] {
       override def blockHash(b: TestBlock)       = b.id
       override def parentBlockHash(b: TestBlock) = b.parentId
       override def isValid(b: Block)             = true
     }
   }
-  type TestAggreement = TestAggreement.type
-  type Hash           = TestAggreement.Hash
+  type TestAgreement = TestAgreement.type
+  type Hash          = TestAgreement.Hash
 
   implicit def `Codec[Set[T]]`[T: Codec] =
     implicitly[Codec[List[T]]].xmap[Set[T]](_.toSet, _.toList)
@@ -45,7 +44,7 @@ object BlockStorageProps extends Properties("BlockStorage") {
   }
 
   object TestBlockStorage
-      extends BlockStorage[Namespace, TestAggreement](
+      extends BlockStorage[Namespace, TestAgreement](
         new KVCollection[Namespace, Hash, TestBlock](Namespace.Blocks),
         new KVCollection[Namespace, Hash, Hash](Namespace.BlockToParent),
         new KVCollection[Namespace, Hash, Set[Hash]](Namespace.BlockToChildren)
@@ -96,7 +95,7 @@ object BlockStorageProps extends Properties("BlockStorage") {
   }
 
   def genBlockId: Gen[Hash] =
-    Gen.delay(UUID.randomUUID().toString)
+    Gen.uuid.map(_.toString)
 
   /** Generate a block with a given parent, using the next available ID. */
   def genBlock(parentId: Hash): Gen[TestBlock] =

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
@@ -28,6 +28,7 @@ object BlockStorageProps extends Properties("BlockStorage") {
     implicit val block = new BlockOps[TestAggreement] {
       override def blockHash(b: TestBlock)       = b.id
       override def parentBlockHash(b: TestBlock) = b.parentId
+      override def isValid(b: Block)             = true
     }
   }
   type TestAggreement = TestAggreement.type

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/BlockStorageProps.scala
@@ -127,10 +127,13 @@ object BlockStorageProps extends Properties("BlockStorage") {
   def genBlockTree: Gen[List[TestBlock]] =
     genBlockTree(parentId = "")
 
-  def genNonEmptyBlockTree: Gen[List[TestBlock]] = for {
-    genesis <- genBlock(parentId = "")
+  def genNonEmptyBlockTree(parentId: Hash): Gen[List[TestBlock]] = for {
+    genesis <- genBlock(parentId = parentId)
     tree    <- genBlockTree(genesis.id)
   } yield genesis +: tree
+
+  def genNonEmptyBlockTree: Gen[List[TestBlock]] =
+    genNonEmptyBlockTree(parentId = "")
 
   case class TestData(
       tree: List[TestBlock],

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizerProps.scala
@@ -1,0 +1,189 @@
+package io.iohk.metronome.hotstuff.service.sync
+
+import cats.effect.concurrent.{Ref, Semaphore}
+import io.iohk.metronome.crypto.GroupSignature
+import io.iohk.metronome.hotstuff.consensus.ViewNumber
+import io.iohk.metronome.hotstuff.consensus.basic.{QuorumCertificate, Phase}
+import io.iohk.metronome.hotstuff.service.storage.BlockStorageProps
+import io.iohk.metronome.storage.InMemoryKVStore
+import org.scalacheck.{Properties, Arbitrary, Gen}, Arbitrary.arbitrary
+import org.scalacheck.Prop.{all, forAll, propBoolean}
+import monix.eval.Task
+import monix.execution.schedulers.TestScheduler
+import scala.util.Random
+import scala.concurrent.duration._
+
+object BlockSynchronizerProps extends Properties("BlockSynchronizer") {
+  import BlockStorageProps.{
+    TestAgreement,
+    TestBlock,
+    TestBlockStorage,
+    TestKVStore,
+    Namespace,
+    genNonEmptyBlockTree,
+    genBlockTree
+  }
+
+  // Insert the prefix three into "persistent" storage,
+  // then start multiple concurrent download processes
+  // from random federation members pointing at various
+  // nodes in the subtree.
+  //
+  // In the end all synced subtree elements should be
+  // persisted and the ephemeral storage left empty.
+  // At no point during the process should the persistent
+  // storage contain a forest.
+  case class TestFixture(
+      ancestorTree: List[TestBlock],
+      descendantTree: List[TestBlock],
+      requests: List[(TestAgreement.PKey, QuorumCertificate[TestAgreement])]
+  ) {
+    val persistentRef = Ref.unsafe[Task, TestKVStore.Store] {
+      TestKVStore.build(ancestorTree)
+    }
+    val ephemeralRef = Ref.unsafe[Task, TestKVStore.Store](Map.empty)
+
+    val persistentStore = InMemoryKVStore[Task, Namespace](persistentRef)
+    val inMemoryStore   = InMemoryKVStore[Task, Namespace](ephemeralRef)
+
+    val blockMap = (ancestorTree ++ descendantTree).map { block =>
+      block.id -> block
+    }.toMap
+
+    def getBlock(
+        from: TestAgreement.PKey,
+        blockHash: TestAgreement.Hash
+    ): Task[Option[TestAgreement.Block]] = {
+      val timeout   = 5000
+      val delay     = Random.nextDouble() * 1000
+      val isLost    = Random.nextDouble() < 0.1
+      val isCorrupt = Random.nextDouble() < 0.1
+
+      val block = if (isCorrupt) {
+        blockMap(blockHash).copy(id = TestFixture.CorruptId)
+      } else {
+        blockMap(blockHash)
+      }
+
+      if (isLost) {
+        Task.pure(None).delayResult(timeout.millis)
+      } else {
+        Task.pure(Some(block)).delayResult(delay.millis)
+      }
+    }
+
+    implicit val storeRunner = persistentStore
+
+    val synchronizer = new BlockSynchronizer[Task, Namespace, TestAgreement](
+      blockStorage = TestBlockStorage,
+      getBlock = getBlock,
+      inMemoryStore = inMemoryStore,
+      semaphore = makeSemapshore()
+    )
+
+    private def makeSemapshore() = {
+      import monix.execution.Scheduler.Implicits.global
+      Semaphore[Task](1).runSyncUnsafe()
+    }
+  }
+  object TestFixture {
+    val CorruptId = "corrupt"
+
+    implicit val arb: Arbitrary[TestFixture] = Arbitrary {
+      for {
+        ancestorTree <- genNonEmptyBlockTree
+        leaf = ancestorTree.last
+        descendantTree <- genBlockTree(parentId = leaf.id)
+
+        federationSize <- Gen.choose(1, 10)
+        federationKeys = Range(0, federationSize).toVector
+
+        existingPrepares <- Gen.someOf(ancestorTree)
+        newPrepares      <- Gen.someOf(descendantTree)
+
+        prepares = (existingPrepares ++ newPrepares).toList
+        proposerKeys <- Gen.listOfN(prepares.size, Gen.oneOf(federationKeys))
+
+        requests = (prepares zip proposerKeys).zipWithIndex.map {
+          case ((parent, publicKey), idx) =>
+            publicKey -> QuorumCertificate[TestAgreement](
+              phase = Phase.Prepare,
+              viewNumber = ViewNumber(100L + idx),
+              blockHash = parent.id,
+              signature = GroupSignature(())
+            )
+        }
+
+      } yield TestFixture(ancestorTree, descendantTree, requests)
+    }
+  }
+
+  property("persists") = forAll { (fixture: TestFixture) =>
+    implicit val scheduler = TestScheduler()
+
+    val test = for {
+      fibers <- Task.parTraverse(fixture.requests) { case (publicKey, qc) =>
+        fixture.synchronizer.sync(publicKey, qc).start
+      }
+      _          <- Task.traverse(fibers)(_.join)
+      persistent <- fixture.persistentRef.get
+      ephemeral  <- fixture.ephemeralRef.get
+    } yield {
+      all(
+        "ephermeral empty" |: ephemeral.isEmpty,
+        "persistent contains all" |: fixture.requests.forall { case (_, qc) =>
+          persistent(Namespace.Blocks).contains(qc.blockHash)
+        },
+        "all uncorrupted" |: persistent(Namespace.Blocks).forall {
+          case (blockHash, block: TestBlock) =>
+            blockHash == block.id && blockHash != TestFixture.CorruptId
+        }
+      )
+    }
+
+    // Schedule the execution, using a Future so we can check the value.
+    val testFuture = test.runToFuture
+
+    // Simulate a long time, which should be enough for all downloads to finish.
+    scheduler.tick(1.day)
+
+    testFuture.value.get.get
+  }
+
+  property("no forest") = forAll(
+    for {
+      fixture  <- arbitrary[TestFixture]
+      duration <- arbitrary[Int].map(_.seconds)
+    } yield (fixture, duration)
+  ) { case (fixture: TestFixture, duration: FiniteDuration) =>
+    implicit val scheduler = TestScheduler()
+
+    // Schedule the downloads in the background.
+    Task
+      .parTraverse(fixture.requests) { case (publicKey, qc) =>
+        fixture.synchronizer.sync(publicKey, qc).startAndForget
+      }
+      .runAsyncAndForget
+
+    // Simulate a some random time, which may or may not be enough to finish the downloads.
+    scheduler.tick(duration)
+
+    // Check now that there the persistent store has just one tree.
+    val test = for {
+      persistent <- fixture.persistentRef.get
+    } yield {
+      persistent(Namespace.Blocks).forall { case (_, block: TestBlock) =>
+        block.parentId.isEmpty || persistent(Namespace.Blocks).contains(
+          block.parentId
+        )
+      }
+    }
+
+    val testFuture = test.runToFuture
+
+    // Just simulate the immediate tasks.
+    scheduler.tick()
+
+    testFuture.value.get.get
+  }
+}

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizerProps.scala
@@ -35,7 +35,8 @@ object BlockSynchronizerProps extends Properties("BlockSynchronizer") {
   case class TestFixture(
       ancestorTree: List[TestBlock],
       descendantTree: List[TestBlock],
-      requests: List[(TestAgreement.PKey, QuorumCertificate[TestAgreement])]
+      requests: List[(TestAgreement.PKey, QuorumCertificate[TestAgreement])],
+      random: Random
   ) {
     val persistentRef = Ref.unsafe[Task, TestKVStore.Store] {
       TestKVStore.build(ancestorTree)
@@ -56,9 +57,9 @@ object BlockSynchronizerProps extends Properties("BlockSynchronizer") {
         blockHash: TestAgreement.Hash
     ): Task[Option[TestAgreement.Block]] = {
       val timeout   = 5000
-      val delay     = Random.nextDouble() * 3000
-      val isLost    = Random.nextDouble() < 0.2
-      val isCorrupt = Random.nextDouble() < 0.2
+      val delay     = random.nextDouble() * 3000
+      val isLost    = random.nextDouble() < 0.2
+      val isCorrupt = random.nextDouble() < 0.2
 
       if (isLost) {
         Task.pure(None).delayResult(timeout.millis)
@@ -115,7 +116,9 @@ object BlockSynchronizerProps extends Properties("BlockSynchronizer") {
             )
         }
 
-      } yield TestFixture(ancestorTree, descendantTree, requests)
+        random <- arbitrary[Int].map(seed => new Random(seed))
+
+      } yield TestFixture(ancestorTree, descendantTree, requests, random)
     }
   }
 

--- a/metronome/storage/src/io/iohk/metronome/storage/InMemoryKVStore.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/InMemoryKVStore.scala
@@ -1,0 +1,21 @@
+package io.iohk.metronome.storage
+
+import cats.implicits._
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+
+/** Simple in-memory key-value store based on `KVStoreState` and `KVStoreRunner`. */
+object InMemoryKVStore {
+  def apply[F[_]: Sync, N]: F[KVStoreRunner[F, N]] =
+    Ref.of[F, KVStoreState[N]#Store](Map.empty).map { storeRef =>
+      new KVStoreState[N] with KVStoreRunner[F, N] {
+        def runReadOnly[A](query: KVStoreRead[N, A]): F[A] =
+          storeRef.get.map(compile(query).run)
+
+        def runReadWrite[A](query: KVStore[N, A]): F[A] =
+          storeRef.modify { store =>
+            compile(query).run(store).value
+          }
+      }
+    }
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/InMemoryKVStore.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/InMemoryKVStore.scala
@@ -7,15 +7,18 @@ import cats.effect.concurrent.Ref
 /** Simple in-memory key-value store based on `KVStoreState` and `KVStoreRunner`. */
 object InMemoryKVStore {
   def apply[F[_]: Sync, N]: F[KVStoreRunner[F, N]] =
-    Ref.of[F, KVStoreState[N]#Store](Map.empty).map { storeRef =>
-      new KVStoreState[N] with KVStoreRunner[F, N] {
-        def runReadOnly[A](query: KVStoreRead[N, A]): F[A] =
-          storeRef.get.map(compile(query).run)
+    Ref.of[F, KVStoreState[N]#Store](Map.empty).map(apply(_))
 
-        def runReadWrite[A](query: KVStore[N, A]): F[A] =
-          storeRef.modify { store =>
-            compile(query).run(store).value
-          }
-      }
+  def apply[F[_]: Sync, N](
+      storeRef: Ref[F, KVStoreState[N]#Store]
+  ): KVStoreRunner[F, N] =
+    new KVStoreState[N] with KVStoreRunner[F, N] {
+      def runReadOnly[A](query: KVStoreRead[N, A]): F[A] =
+        storeRef.get.map(compile(query).run)
+
+      def runReadWrite[A](query: KVStore[N, A]): F[A] =
+        storeRef.modify { store =>
+          compile(query).run(store).value
+        }
     }
 }


### PR DESCRIPTION
Required PRs are https://github.com/input-output-hk/metronome/pull/29, https://github.com/input-output-hk/metronome/pull/28, https://github.com/input-output-hk/metronome/pull/25 and https://github.com/input-output-hk/metronome/pull/31

* Added an `RPCTracker` component that can match (optional) responses to requests, or issue a timeout.
* Added `BlockSynchronizer` to download and persist blocks that have a Quorum Certificate.
* Wired together `SyncService` and `BlockSynchronizer`. 
* Enhanced `FiberMap` with the ability the cancel the enqueued tasks of a key.

The idea is that we have a block tree in persistent storage, but sometimes a `Prepare` message can contain a block we don't have a parent for. But the `Prepare` message contains the Quorum Certificate for that parent, so we know that it's already been vetted by the federation and it's safe to download and store - we don't even need to validate it, similarly to how we can just adopt any state that has a Commit Q.C. for it without validating its history. 

The `BlockSynchronizer` downloads ancestors of the High Q.C. until it finds a block that is already in persistent storage. The blocks it's downloading go in an in-memory block store until they can be connected to the persistent tree, at which point they are moved over. This way we never risk ending up with a forest in the persistent store if the program crashes in the middle of a download sequence, which would make pruning difficult later. 

However, this means we are limited in how much we can download by the amount of memory we have. We made it an assumption that this block-by-block download is happening only when we're in-sync with the other federation members and the number of missing blocks is likely to be very small. Otherwise the HotStuff service will recognise that it's out of sync and trigger state synchronisation, which polls the members for the highest commit Q.C. and requests a jump directly there. So the overall application is expected to be able to do _something_ to carry out a faster than normal synchronisation to any given block hash, which will not use the mechanism in the `BlockSynchronizer`. 

When it's time to switch from regular block synchronisation to jump synchronisation, the `SyncService` will be equipped with the means to cancel all outstanding downloads, sync the state, prune the existing block store, re-kindle it from the new block, then resume normal sync.

The `BlockSynchronizer` itself is simplistic at the moment: in each round we can start downloading one more High Q.C. from whoever the current leader is. We could expect other members of the federation to have this block as well, (although we don't necessarily know who signed the Q.C. if we use threshold cryptography), however, currently adding an alternative source comes naturally if the next leader also builds on the same, or a descendant High Q.C. At that point multiple fibers will be ascending the same chain, potentially downloading any missing block from multiple sources, until one of them succeeds. Only one request is issued to any given federation member at a time.