### PR TITLE
PM-3105: Ledger persistence

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -314,7 +314,10 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
           checkpointing.interpreter
         )
 
-      object test extends TestModule
+      object test extends TestModule {
+        override def moduleDeps: Seq[JavaModule] =
+          super.moduleDeps ++ Seq(checkpointing.models.test)
+      }
     }
 
     /** Executable application for running HotStuff and checkpointing as a stand-alone process,

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/storage/LedgerStorage.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/storage/LedgerStorage.scala
@@ -1,5 +1,6 @@
 package io.iohk.metronome.checkpointing.service.storage
 
+import cats.implicits._
 import io.iohk.metronome.checkpointing.models.Ledger
 import io.iohk.metronome.storage.{KVRingBuffer, KVCollection, KVStore}
 import scodec.Codec
@@ -38,5 +39,5 @@ class LedgerStorage[N](
     * by going through a block pointing at them directly.
     */
   def put(ledger: Ledger): KVStore[N, Unit] =
-    put(ledger.hash, ledger)
+    put(ledger.hash, ledger).void
 }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/storage/LedgerStorage.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/storage/LedgerStorage.scala
@@ -1,0 +1,91 @@
+package io.iohk.metronome.checkpointing.service.storage
+
+import cats.implicits._
+import io.iohk.metronome.checkpointing.models.Ledger
+import io.iohk.metronome.storage.{KVCollection, KVStore, KVStoreRead}
+import scodec.{Decoder, Encoder, Codec}
+
+/** Storing the committed and executed checkpoint ledger.
+  *
+  * Strictly speaking the application only needs the committed state,
+  * since it has been signed by the federation and we know it's not
+  * going to be rolled back. Uncommitted state can be kept in memory.
+  *
+  * However we want to support other nodes catching up by:
+  * 1. requesting the latest Commit Q.C., then
+  * 2. requesting the block the Commit Q.C. points at, then
+  * 3. requesting the ledger state the header points at.
+  *
+  * We have to allow some time before we get rid of historical state,
+  * so that it doesn't disappear between step 2 and 3, resulting in
+  * nodes trying and trying to catch up but always missing the beat.
+  *
+  * Therefore we keep a collection of the last N ledgers in a ring buffer.
+  */
+class LedgerStorage[N](
+    ledgerColl: KVCollection[N, Ledger.Hash, Ledger],
+    ledgerMetaNamespace: N,
+    maxHistorySize: Int
+)(implicit codecH: Codec[Ledger.Hash]) {
+  import LedgerStorage._
+  import scodec.codecs.implicits.implicitIntCodec
+
+  private implicit val kvn  = KVStore.instance[N]
+  private implicit val kvrn = KVStoreRead.instance[N]
+
+  private def getMetaData[V: Decoder](key: MetaKey[V]) =
+    KVStore[N].get[MetaKey[V], V](ledgerMetaNamespace, key)
+
+  private def putMetaData[V: Encoder](key: MetaKey[V], value: V) =
+    KVStore[N].put(ledgerMetaNamespace, key, value)
+
+  private def nextIndex(maybeIndex: Option[Int]): Int =
+    maybeIndex.fold(0)(index => (index + 1) % maxHistorySize)
+
+  /** Save a new ledger and remove the oldest one, if we reached
+    * the maximum history size. Since we only store committed
+    * state, they form a chain. They will always be retrieved
+    * by going through a block pointing at them directly.
+    */
+  def put(ledger: Ledger): KVStore[N, Unit] =
+    for {
+      index <- getMetaData(BucketIndex).map(nextIndex)
+      ledgerHash = ledger.hash
+      maybeOldestHash <- getMetaData(Bucket(index))
+      _ <- maybeOldestHash match {
+        case Some(oldestHash) if oldestHash == ledgerHash =>
+          KVStore[N].unit
+
+        case Some(oldestHash) =>
+          ledgerColl.put(ledgerHash, ledger) >>
+            ledgerColl.delete(oldestHash)
+
+        case None =>
+          ledgerColl.put(ledgerHash, ledger)
+      }
+      _ <- putMetaData(Bucket(index), ledgerHash)
+      _ <- putMetaData(BucketIndex, index)
+    } yield ()
+
+  /** Retrieve a ledger by state hash, if we still have it. */
+  def get(ledgerHash: Ledger.Hash): KVStoreRead[N, Option[Ledger]] =
+    ledgerColl.read(ledgerHash)
+}
+
+object LedgerStorage {
+
+  /** Keys for different pieces of meta-data stored under a single namespace. */
+  sealed trait MetaKey[V]
+
+  /** Key under which the current bucket index of the ring buffer is stored. */
+  case object BucketIndex extends MetaKey[Int]
+
+  /** Contents of a bucket by index. */
+  case class Bucket(index: Int) extends MetaKey[Ledger.Hash]
+
+  implicit val metaKeyEncoder: Encoder[MetaKey[_]] =
+    scodec.codecs.implicits.implicitIntCodec.asEncoder.contramap {
+      case BucketIndex   => -1
+      case Bucket(index) => index
+    }
+}

--- a/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/storage/LedgerStorageProps.scala
+++ b/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/storage/LedgerStorageProps.scala
@@ -1,0 +1,76 @@
+package io.iohk.metronome.checkpointing.service.storage
+
+import cats.implicits._
+import io.iohk.metronome.core.Tagger
+import io.iohk.metronome.checkpointing.models.Ledger
+import io.iohk.metronome.checkpointing.models.ArbitraryInstances
+import io.iohk.metronome.storage.{KVCollection, KVStoreState}
+import org.scalacheck.{Properties, Gen, Arbitrary}, Arbitrary.arbitrary
+import org.scalacheck.Prop.{forAll, all, propBoolean}
+import scodec.Codec
+import scodec.bits.BitVector
+import org.scalacheck.Shrink
+import scala.annotation.nowarn
+
+object LedgerStorageProps extends Properties("LedgerStorage") {
+  import ArbitraryInstances.arbLedger
+
+  type Namespace = String
+  object Namespace {
+    val Ledgers    = "ledgers"
+    val LedgerMeta = "ledger-meta"
+  }
+
+  /** The in-memory KVStoreState doesn't invoke the codecs. */
+  implicit def neverUsedCodec[T] =
+    Codec[T](
+      (_: T) => sys.error("Didn't expect to encode."),
+      (_: BitVector) => sys.error("Didn't expect to decode.")
+    )
+
+  object TestKVStore extends KVStoreState[Namespace]
+
+  object HistorySize extends Tagger[Int] {
+    @nowarn
+    implicit val shrink: Shrink[HistorySize] = Shrink(s => Stream.empty)
+    implicit val arb: Arbitrary[HistorySize] = Arbitrary {
+      Gen.choose(1, 10).map(HistorySize(_))
+    }
+  }
+  type HistorySize = HistorySize.Tagged
+
+  property("buffer") = forAll(
+    for {
+      ledgers <- arbitrary[List[Ledger]]
+      maxSize <- arbitrary[HistorySize]
+    } yield (ledgers, maxSize)
+  ) { case (ledgers, maxSize) =>
+    val ledgerStorage = new LedgerStorage[Namespace](
+      new KVCollection[Namespace, Ledger.Hash, Ledger](Namespace.Ledgers),
+      Namespace.LedgerMeta,
+      maxHistorySize = maxSize
+    )
+
+    val store =
+      TestKVStore
+        .compile(ledgers.traverse(ledgerStorage.put))
+        .runS(Map.empty)
+        .value
+
+    def getByHash(ledgerHash: Ledger.Hash) =
+      TestKVStore.compile(ledgerStorage.get(ledgerHash)).run(store)
+
+    val ledgerMap      = store.get(Namespace.Ledgers).getOrElse(Map.empty[Any, Any])
+    val (current, old) = ledgers.reverse.splitAt(maxSize)
+
+    all(
+      "max-history" |: ledgerMap.values.size <= maxSize,
+      "contains current" |: current.forall { ledger =>
+        getByHash(ledger.hash).contains(ledger)
+      },
+      "not contain old" |: old.forall { ledger =>
+        getByHash(ledger.hash).isEmpty
+      }
+    )
+  }
+}

--- a/metronome/storage/src/io/iohk/metronome/storage/KVRingBuffer.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVRingBuffer.scala
@@ -16,39 +16,84 @@ class KVRingBuffer[N, K, V](
 
   private implicit val kvn = KVStore.instance[N]
 
+  private implicit val metaKeyEncoder: Encoder[MetaKey[_]] = {
+    import scodec.codecs._
+    import scodec.codecs.implicits._
+
+    val bucketIndexCodec                        = provide(BucketIndex)
+    val bucketCodec: Codec[Bucket[_]]           = Codec.deriveLabelledGeneric
+    val keyRefCountCodec: Codec[KeyRefCount[K]] = Codec.deriveLabelledGeneric
+
+    discriminated[MetaKey[_]]
+      .by(uint2)
+      .typecase(0, bucketIndexCodec)
+      .typecase(1, bucketCodec)
+      .typecase(2, keyRefCountCodec)
+      .asEncoder
+  }
+
   private def getMetaData[V: Decoder](key: MetaKey[V]) =
     KVStore[N].get[MetaKey[V], V](metaNamespace, key)
 
   private def putMetaData[V: Encoder](key: MetaKey[V], value: V) =
     KVStore[N].put(metaNamespace, key, value)
 
+  private def setRefCount(key: K, count: Int) =
+    if (count > 0)
+      putMetaData[Int](KeyRefCount(key), count)
+    else
+      KVStore[N].delete(metaNamespace, KeyRefCount(key))
+
+  private def getRefCount(key: K) =
+    getMetaData[Int](KeyRefCount(key)).map(_ getOrElse 0)
+
   /** Return the index of the next bucket to write the data into. */
   private def nextIndex(maybeIndex: Option[Int]): Int =
     maybeIndex.fold(0)(index => (index + 1) % maxHistorySize)
 
+  private def add(key: K, value: V) =
+    getRefCount(key).flatMap { cnt =>
+      if (cnt == 0)
+        setRefCount(key, 1) >> coll.put(key, value)
+      else
+        setRefCount(key, cnt + 1)
+    }
+
+  private def maybeRemove(key: K) =
+    getRefCount(key).flatMap { cnt =>
+      if (cnt > 1)
+        setRefCount(key, cnt - 1).as(none[K])
+      else
+        setRefCount(key, 0) >> coll.delete(key).as(key.some)
+    }
+
   /** Save a new item and remove the oldest one, if we reached
     * the maximum history size.
+    *
+    * Returns the key which has been evicted, unless it's still
+    * referenced by something or the history hasn't reached maximum
+    * size yet.
     */
-  def put(key: K, value: V): KVStore[N, Unit] =
+  def put(key: K, value: V): KVStore[N, Option[K]] = {
     for {
       index          <- getMetaData(BucketIndex).map(nextIndex)
       maybeOldestKey <- getMetaData(Bucket[K](index))
-      _ <- maybeOldestKey match {
+      maybeRemoved <- maybeOldestKey match {
         case Some(oldestKey) if oldestKey == key =>
-          KVStore[N].unit
+          KVStore[N].pure(none[K])
 
         case Some(oldestKey) =>
-          coll.put(key, value) >>
-            coll.delete(oldestKey)
+          add(key, value) >> maybeRemove(oldestKey)
 
         case None =>
-          coll.put(key, value)
+          add(key, value).as(none[K])
       }
       _ <- putMetaData(Bucket(index), key)
       _ <- putMetaData(BucketIndex, index)
-    } yield ()
+    } yield maybeRemoved
+  }
 
-  /** Retrieve an item hash hash, if we still have it. */
+  /** Retrieve an item by hash, if we still have it. */
   def get(key: K): KVStoreRead[N, Option[V]] =
     coll.read(key)
 }
@@ -56,7 +101,7 @@ class KVRingBuffer[N, K, V](
 object KVRingBuffer {
 
   /** Keys for different pieces of meta-data stored under a single namespace. */
-  sealed trait MetaKey[V]
+  sealed trait MetaKey[+V]
 
   /** Key under which the last written index of the ring buffer is stored. */
   case object BucketIndex extends MetaKey[Int]
@@ -66,9 +111,6 @@ object KVRingBuffer {
     assert(index >= 0)
   }
 
-  implicit val metaKeyEncoder: Encoder[MetaKey[_]] =
-    scodec.codecs.implicits.implicitIntCodec.asEncoder.contramap {
-      case BucketIndex   => -1
-      case Bucket(index) => index
-    }
+  /** Number of buckets currently pointing at a key. */
+  case class KeyRefCount[K](key: K) extends MetaKey[Int]
 }

--- a/metronome/storage/src/io/iohk/metronome/storage/KVRingBuffer.scala
+++ b/metronome/storage/src/io/iohk/metronome/storage/KVRingBuffer.scala
@@ -1,0 +1,74 @@
+package io.iohk.metronome.storage
+
+import cats.implicits._
+import scodec.{Decoder, Encoder, Codec}
+
+/** Storing the last N items inserted into a collection. */
+class KVRingBuffer[N, K, V](
+    coll: KVCollection[N, K, V],
+    metaNamespace: N,
+    maxHistorySize: Int
+)(implicit codecK: Codec[K]) {
+  require(maxHistorySize > 0, "Has to store at least one item in the buffer.")
+
+  import KVRingBuffer._
+  import scodec.codecs.implicits.implicitIntCodec
+
+  private implicit val kvn = KVStore.instance[N]
+
+  private def getMetaData[V: Decoder](key: MetaKey[V]) =
+    KVStore[N].get[MetaKey[V], V](metaNamespace, key)
+
+  private def putMetaData[V: Encoder](key: MetaKey[V], value: V) =
+    KVStore[N].put(metaNamespace, key, value)
+
+  /** Return the index of the next bucket to write the data into. */
+  private def nextIndex(maybeIndex: Option[Int]): Int =
+    maybeIndex.fold(0)(index => (index + 1) % maxHistorySize)
+
+  /** Save a new item and remove the oldest one, if we reached
+    * the maximum history size.
+    */
+  def put(key: K, value: V): KVStore[N, Unit] =
+    for {
+      index          <- getMetaData(BucketIndex).map(nextIndex)
+      maybeOldestKey <- getMetaData(Bucket[K](index))
+      _ <- maybeOldestKey match {
+        case Some(oldestKey) if oldestKey == key =>
+          KVStore[N].unit
+
+        case Some(oldestKey) =>
+          coll.put(key, value) >>
+            coll.delete(oldestKey)
+
+        case None =>
+          coll.put(key, value)
+      }
+      _ <- putMetaData(Bucket(index), key)
+      _ <- putMetaData(BucketIndex, index)
+    } yield ()
+
+  /** Retrieve an item hash hash, if we still have it. */
+  def get(key: K): KVStoreRead[N, Option[V]] =
+    coll.read(key)
+}
+
+object KVRingBuffer {
+
+  /** Keys for different pieces of meta-data stored under a single namespace. */
+  sealed trait MetaKey[V]
+
+  /** Key under which the last written index of the ring buffer is stored. */
+  case object BucketIndex extends MetaKey[Int]
+
+  /** Contents of a ring buffer bucket by index. */
+  case class Bucket[V](index: Int) extends MetaKey[V] {
+    assert(index >= 0)
+  }
+
+  implicit val metaKeyEncoder: Encoder[MetaKey[_]] =
+    scodec.codecs.implicits.implicitIntCodec.asEncoder.contramap {
+      case BucketIndex   => -1
+      case Bucket(index) => index
+    }
+}


### PR DESCRIPTION
Adds a `LedgerStorage` component that stores a certain number of the latest ledger instances in a ring buffer. The idea is that we only need to keep the last committed state, however we want to leave some time for other nodes that may need to sync with us to request it, so we can configure a lag after which the oldest ledger is overwritten. 

It is located in `checkpointing.service.storages` so it doesn't have to deal with anything generic, we know the ledger is going to be small. 

Builds on https://github.com/input-output-hk/metronome/pull/31 so keys don't need `Codec` just `Encoder`.