### PR TITLE
PM-3063: View synchronisation

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -251,7 +251,10 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
           hotstuff.forensics
         )
 
-      object test extends TestModule
+      object test extends TestModule {
+        override def moduleDeps: Seq[JavaModule] =
+          super.moduleDeps ++ Seq(hotstuff.consensus.test)
+      }
     }
   }
 

--- a/metronome/core/src/io/iohk/metronome/core/fibers/FiberSet.scala
+++ b/metronome/core/src/io/iohk/metronome/core/fibers/FiberSet.scala
@@ -16,9 +16,7 @@ class FiberSet[F[_]: Concurrent](
 ) {
   private def raiseIfShutdown: F[Unit] =
     isShutdownRef.get.ifM(
-      Concurrent[F].raiseError(
-        new IllegalStateException("The pool is already shut down.")
-      ),
+      Concurrent[F].raiseError(new FiberSet.ShutdownException),
       ().pure[F]
     )
 
@@ -57,6 +55,9 @@ class FiberSet[F[_]: Concurrent](
 }
 
 object FiberSet {
+  class ShutdownException
+      extends IllegalStateException("The pool is already shut down.")
+
   def apply[F[_]: Concurrent]: Resource[F, FiberSet[F]] =
     Resource.make[F, FiberSet[F]] {
       for {

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/Federation.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/Federation.scala
@@ -23,7 +23,7 @@ package io.iohk.metronome.hotstuff.consensus
   *
   * Extra: The above two inequalities `(n+f)/2 < q <= n-f`, lead to the constraint: `f < n/3`, or `n >= 3*f+1`.
   */
-abstract case class Federation[PKey](
+abstract case class Federation[PKey] private (
     publicKeys: IndexedSeq[PKey],
     // Maximum number of Byzantine nodes.
     maxFaulty: Int

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/ViewNumber.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/ViewNumber.scala
@@ -1,6 +1,7 @@
 package io.iohk.metronome.hotstuff.consensus
 
 import io.iohk.metronome.core.Tagger
+import cats.kernel.Order
 
 object ViewNumber extends Tagger[Long] {
   implicit class Ops(val vn: ViewNumber) extends AnyVal {
@@ -10,4 +11,7 @@ object ViewNumber extends Tagger[Long] {
 
   implicit val ord: Ordering[ViewNumber] =
     Ordering.by(identity[Long])
+
+  implicit val order: Order[ViewNumber] =
+    Order.fromOrdering(ord)
 }

--- a/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
+++ b/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
@@ -313,7 +313,8 @@ object ProtocolStateCommands extends Commands {
         genLazy(
           qc.copy[TestAgreement](blockHash = invalidateHash(qc.blockHash))
         ),
-        genLazy(qc.copy[TestAgreement](phase = nextVoting(qc.phase))),
+        genLazy(qc.copy[TestAgreement](phase = nextVoting(qc.phase)))
+          .suchThat(_.blockHash != genesisQC.blockHash),
         genLazy(
           qc.copy[TestAgreement](viewNumber =
             invalidateViewNumber(qc.viewNumber)

--- a/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
+++ b/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
@@ -14,9 +14,9 @@ import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.util.{Try, Failure, Success}
 
-object HotStuffProtocolProps extends Properties("Basic HotStuff") {
+object ProtocolStateProps extends Properties("Basic HotStuff") {
 
-  property("protocol") = HotStuffProtocolCommands.property()
+  property("protocol") = ProtocolStateCommands.property()
 
 }
 
@@ -26,7 +26,7 @@ object HotStuffProtocolProps extends Properties("Basic HotStuff") {
   * and invalid commands using `genCommand`. Each `Command`, has its individual post-condition
   * check comparing the model state to the actual protocol results.
   */
-object HotStuffProtocolCommands extends Commands {
+object ProtocolStateCommands extends Commands {
 
   case class TestBlock(blockHash: Int, parentBlockHash: Int, command: String)
 
@@ -71,12 +71,10 @@ object HotStuffProtocolCommands extends Commands {
         (phase, viewNumber, blockHash).hashCode
 
       private def isGenesis(
-          phase: VotingPhase,
           viewNumber: ViewNumber,
           blockHash: TestAgreement.Hash
       ): Boolean =
-        phase == genesisQC.phase &&
-          viewNumber == genesisQC.viewNumber &&
+        viewNumber == genesisQC.viewNumber &&
           blockHash == genesisQC.blockHash
 
       private def sign(
@@ -125,7 +123,7 @@ object HotStuffProtocolCommands extends Commands {
           viewNumber: ViewNumber,
           blockHash: TestAgreement.Hash
       ): Boolean = {
-        if (isGenesis(phase, viewNumber, blockHash)) {
+        if (isGenesis(viewNumber, blockHash)) {
           signature.sig.isEmpty
         } else {
           val h = hash(phase, viewNumber, blockHash)

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -168,16 +168,20 @@ class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
   /** Process the synchronization result queue. */
   private def processSyncPipe: F[Unit] =
     syncPipe.receive
-      .mapEval[Unit] { case SyncPipe.PrepareResponse(request, isValid) =>
-        if (isValid) {
-          enqueueEvent(
-            validated(Event.MessageReceived(request.sender, request.prepare))
-          )
-        } else {
-          protocolError(
-            ProtocolError.UnsafeExtension(request.sender, request.prepare)
-          )
-        }
+      .mapEval[Unit] {
+        case SyncPipe.PrepareResponse(request, isValid) =>
+          if (isValid) {
+            enqueueEvent(
+              validated(Event.MessageReceived(request.sender, request.prepare))
+            )
+          } else {
+            protocolError(
+              ProtocolError.UnsafeExtension(request.sender, request.prepare)
+            )
+          }
+
+        case SyncPipe.StatusResponse(status) =>
+          ???
       }
       .completedL
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -15,6 +15,7 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   Phase,
   Message,
   Block,
+  Signing,
   QuorumCertificate
 }
 import io.iohk.metronome.hotstuff.service.pipes.SyncPipe
@@ -34,7 +35,9 @@ import scala.util.control.NonFatal
   *
   * It handles the `consensus.basic.Message` events coming from the network.
   */
-class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
+class ConsensusService[F[
+    _
+]: Timer: Concurrent, N, A <: Agreement: Block: Signing](
     publicKey: A#PKey,
     network: Network[F, A, Message[A]],
     blockStorage: BlockStorage[N, A],
@@ -181,9 +184,24 @@ class ConsensusService[F[_]: Timer: Concurrent, N, A <: Agreement: Block](
           }
 
         case SyncPipe.StatusResponse(status) =>
-          ???
+          fastForwardState(status)
       }
       .completedL
+
+  /** Replace the current protocol state based on what was synced with the federation. */
+  private def fastForwardState(status: Status[A]): F[Unit] = {
+    stateRef.get.flatMap { state =>
+      val forward = state.copy[A](
+        viewNumber = status.viewNumber,
+        prepareQC = status.prepareQC,
+        commitQC = status.commitQC
+      )
+      // Trigger the next view, so we get proper tracing and effect execution.
+      handleTransition {
+        forward.handleNextView(Event.NextView(forward.viewNumber))
+      }
+    }
+  }
 
   /** Add a validated event to the queue for processing against the protocol state. */
   private def enqueueEvent(event: Validated[Event[A]]): F[Unit] =
@@ -474,7 +492,9 @@ object ConsensusService {
     * `initState` is expected to be restored from persistent storage
     * instances upon restart.
     */
-  def apply[F[_]: Timer: Concurrent: ContextShift, N, A <: Agreement: Block](
+  def apply[F[
+      _
+  ]: Timer: Concurrent: ContextShift, N, A <: Agreement: Block: Signing](
       publicKey: A#PKey,
       network: Network[F, A, Message[A]],
       blockStorage: BlockStorage[N, A],
@@ -510,7 +530,7 @@ object ConsensusService {
 
   private def build[F[
       _
-  ]: Timer: Concurrent: ContextShift, N, A <: Agreement: Block](
+  ]: Timer: Concurrent: ContextShift, N, A <: Agreement: Block: Signing](
       publicKey: A#PKey,
       network: Network[F, A, Message[A]],
       blockStorage: BlockStorage[N, A],

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
@@ -14,7 +14,7 @@ import io.iohk.metronome.hotstuff.service.messages.{
   HotStuffMessage,
   SyncMessage
 }
-import io.iohk.metronome.hotstuff.service.pipes.BlockSyncPipe
+import io.iohk.metronome.hotstuff.service.pipes.SyncPipe
 import io.iohk.metronome.hotstuff.service.storage.{
   BlockStorage,
   ViewStateStorage
@@ -57,14 +57,14 @@ object HotStuffService {
           }
         )
 
-      blockSyncPipe <- Resource.liftF { BlockSyncPipe[F, A] }
+      syncPipe <- Resource.liftF { SyncPipe[F, A] }
 
       consensusService <- ConsensusService(
         publicKey,
         consensusNetwork,
         blockStorage,
         viewStateStorage,
-        blockSyncPipe.left,
+        syncPipe.left,
         initState
       )
 
@@ -73,7 +73,7 @@ object HotStuffService {
         federation,
         syncNetwork,
         blockStorage,
-        blockSyncPipe.right,
+        syncPipe.right,
         consensusService.getState
       )
     } yield ()

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
@@ -63,6 +63,7 @@ object HotStuffService {
       )
 
       syncService <- SyncService(
+        publicKey,
         syncNetwork,
         blockStorage,
         blockSyncPipe.right,

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
@@ -73,6 +73,7 @@ object HotStuffService {
         federation,
         syncNetwork,
         blockStorage,
+        viewStateStorage,
         syncPipe.right,
         consensusService.getState
       )

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
@@ -1,9 +1,7 @@
 package io.iohk.metronome.hotstuff.service
 
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
-import io.iohk.metronome.hotstuff.consensus.basic.Agreement
-import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
-import io.iohk.metronome.hotstuff.consensus.basic.Phase
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
 
 /** Status has all the fields necessary for nodes to sync with each other.
   *
@@ -14,7 +12,4 @@ case class Status[A <: Agreement](
     viewNumber: ViewNumber,
     prepareQC: QuorumCertificate[A],
     commitQC: QuorumCertificate[A]
-) {
-  require(prepareQC.phase == Phase.Prepare)
-  require(commitQC.phase == Phase.Commit)
-}
+)

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
@@ -3,6 +3,7 @@ package io.iohk.metronome.hotstuff.service
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
 import io.iohk.metronome.hotstuff.consensus.basic.Agreement
 import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import io.iohk.metronome.hotstuff.consensus.basic.Phase
 
 /** Status has all the fields necessary for nodes to sync with each other.
   *
@@ -13,4 +14,7 @@ case class Status[A <: Agreement](
     viewNumber: ViewNumber,
     prepareQC: QuorumCertificate[A],
     commitQC: QuorumCertificate[A]
-)
+) {
+  require(prepareQC.phase == Phase.Prepare)
+  require(commitQC.phase == Phase.Commit)
+}

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -8,10 +8,12 @@ import io.iohk.metronome.core.messages.{
   RPCPair,
   RPCTracker
 }
+import io.iohk.metronome.hotstuff.consensus.Federation
 import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
   ProtocolState,
-  Block
+  Block,
+  Signing
 }
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 import io.iohk.metronome.hotstuff.service.pipes.BlockSyncPipe
@@ -23,6 +25,8 @@ import io.iohk.metronome.storage.KVStoreRunner
 import scala.util.control.NonFatal
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
+import io.iohk.metronome.hotstuff.service.sync.ViewSynchronizer
+import cats.Parallel
 
 /** The `SyncService` handles the `SyncMessage`s coming from the network,
   * i.e. serving block and status requests, as well as receive responses
@@ -180,9 +184,9 @@ class SyncService[F[_]: Sync, N, A <: Agreement](
                 for {
                   _       <- blockSynchronizer.sync(sender, prepare.highQC)
                   isValid <- validateBlock(prepare.block)
-                  _ <- blockSyncPipe.send(
+                  _ <- blockSyncPipe.send {
                     BlockSyncPipe.Response(request, isValid)
-                  )
+                  }
                 } yield ()
               }
               .void
@@ -200,8 +204,11 @@ object SyncService {
     * in the background, shutting processing down when the resource is
     * released.
     */
-  def apply[F[_]: Concurrent: ContextShift: Timer, N, A <: Agreement: Block](
+  def apply[F[
+      _
+  ]: Concurrent: ContextShift: Timer: Parallel, N, A <: Agreement: Block: Signing](
       publicKey: A#PKey,
+      federation: Federation[A#PKey],
       network: Network[F, A, SyncMessage[A]],
       blockStorage: BlockStorage[N, A],
       blockSyncPipe: BlockSyncPipe[F, A]#Right,
@@ -231,6 +238,7 @@ object SyncService {
       blockSync <- Resource.liftF {
         BlockSynchronizer[F, N, A](blockStorage, service.getBlock)
       }
+      viewSync = new ViewSynchronizer[F, A](federation, service.getStatus)
       _ <- Concurrent[F].background(service.processNetworkMessages)
       _ <- Concurrent[F].background(service.processBlockSyncPipe(blockSync))
     } yield service

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -327,9 +327,7 @@ class SyncService[F[_]: Concurrent, N, A <: Agreement: Block](
         // Considering the committed block as executed, we have its state already.
         _ <- viewStateStorage.setLastExecutedBlockHash(blockHash)
         _ <- viewStateStorage.setRootBlockHash(blockHash)
-        _ <- viewStateStorage.setViewNumber(status.viewNumber)
-        _ <- viewStateStorage.setQuorumCertificate(status.prepareQC)
-        _ <- viewStateStorage.setQuorumCertificate(status.commitQC)
+        // The rest of the fields will be set by the ConsensusService.
       } yield ()
 
     storeRunner.runReadWrite(query)

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -2,13 +2,14 @@ package io.iohk.metronome.hotstuff.service
 
 import cats.implicits._
 import cats.effect.{Sync, Resource, Concurrent, ContextShift, Timer}
+import cats.effect.concurrent.Ref
 import io.iohk.metronome.core.fibers.FiberMap
 import io.iohk.metronome.core.messages.{
   RPCMessageCompanion,
   RPCPair,
   RPCTracker
 }
-import io.iohk.metronome.hotstuff.consensus.Federation
+import io.iohk.metronome.hotstuff.consensus.{Federation, ViewNumber}
 import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
   ProtocolState,
@@ -45,10 +46,12 @@ class SyncService[F[_]: Sync, N, A <: Agreement](
     syncPipe: SyncPipe[F, A]#Right,
     getState: F[ProtocolState[A]],
     incomingFiberMap: FiberMap[F, A#PKey],
-    syncFiberMap: FiberMap[F, A#PKey],
     rpcTracker: RPCTracker[F, SyncMessage[A]]
 )(implicit tracers: SyncTracers[F, A], storeRunner: KVStoreRunner[F, N]) {
   import SyncMessage._
+  import SyncService.SyncMode
+
+  type SyncModeRef = Ref[F, SyncMode[F, N, A]]
 
   private def protocolStatus: F[Status[A]] =
     getState.map { state =>
@@ -156,42 +159,98 @@ class SyncService[F[_]: Sync, N, A <: Agreement](
   /** Read Requests from the SyncPipe and send Responses.
     *
     * These are coming from the `ConsensusService` asking for a
-    * `Prepare` message to be synchronised with the sender.
+    * `Prepare` message to be synchronized with the sender, or
+    * for the view to be synchronized with the whole federation.
     */
   private def processSyncPipe(
-      blockSynchronizer: BlockSynchronizer[F, N, A]
+      syncModeFactory: SyncMode.Factory[F, N, A]
   ): F[Unit] = {
-    syncPipe.receive
-      .mapEval[Unit] {
-        // TODO (PM-3063): Change `SyncPipe` to just `SyncPipe` and add
-        // ViewState sync requests which poll the fedreation for the latest
-        // Commit Q.C. and jump to it. When that signal comes, cancel the
-        // `syncFiberMap`, discard the `blockSynchronizer` and move over to
-        // state syncing, then create a new new block synchronizer and resume.
-        // For this, change the input of this method to a `F[BlockSynchronizer[F,N,A]]`
-        // and call some mutually recursive method representing different states:
+    syncModeFactory
+      .block(ViewNumber(0))
+      .flatMap(Ref.of[F, SyncMode[F, N, A]](_))
+      .flatMap { syncModeRef =>
+        syncPipe.receive
+          .mapEval[Unit] {
+            case request @ SyncPipe.PrepareRequest(_, _) =>
+              handlePrepareRequest(syncModeRef, request)
 
-        case request @ SyncPipe.PrepareRequest(sender, prepare) =>
-          // It is enough to respond to the last block positively, it will indicate
-          // that the whole range can be executed later (at that point from storage).
-          // If the same leader is sending us newer proposals, we can ignore the
-          // previous pepared blocks - they are either part of the new Q.C.,
-          // in which case they don't need to be validated, or they have not
-          // gathered enough votes, and been superseded by a new proposal.
-          syncFiberMap.cancelQueue(sender) >>
-            syncFiberMap
-              .submit(sender) {
-                for {
-                  _       <- blockSynchronizer.sync(sender, prepare.highQC)
-                  isValid <- validateBlock(prepare.block)
-                  _ <- syncPipe.send {
-                    SyncPipe.PrepareResponse(request, isValid)
-                  }
-                } yield ()
-              }
-              .void
+            case request @ SyncPipe.StatusRequest(_) =>
+              handleStatusRequest(
+                syncModeRef,
+                syncModeFactory,
+                request
+              )
+          }
+          .completedL
       }
-      .completedL
+  }
+
+  private def handlePrepareRequest(
+      syncModeRef: SyncModeRef,
+      request: SyncPipe.PrepareRequest[A]
+  ): F[Unit] = {
+    syncModeRef.get.flatMap {
+      case SyncMode.View(_) =>
+        // We're in the process of syncing the view, so we can ignore any further
+        // blocks until we switch back.
+        ().pure[F]
+
+      case SyncMode.Block(blockSynchronizer, syncFiberMap, _, _) =>
+        val sender  = request.sender
+        val prepare = request.prepare
+        // It is enough to respond to the last block positively, it will indicate
+        // that the whole range can be executed later (at that point from storage).
+        // If the same leader is sending us newer proposals, we can ignore the
+        // previous pepared blocks - they are either part of the new Q.C.,
+        // in which case they don't need to be validated, or they have not
+        // gathered enough votes, and been superseded by a new proposal.
+        syncFiberMap.cancelQueue(sender) >>
+          syncFiberMap
+            .submit(sender) {
+              for {
+                _       <- blockSynchronizer.sync(sender, prepare.highQC)
+                isValid <- validateBlock(prepare.block)
+                _       <- syncPipe.send(SyncPipe.PrepareResponse(request, isValid))
+              } yield ()
+            }
+            .attemptNarrow[FiberMap.ShutdownException] // Ignore shutdowns
+            .void
+    }
+  }
+
+  private def handleStatusRequest(
+      syncModeRef: SyncModeRef,
+      syncModeFactory: SyncMode.Factory[F, N, A],
+      request: SyncPipe.StatusRequest
+  ): F[Unit] = {
+    syncModeRef.get.flatMap {
+      case SyncMode.View(_) =>
+        // We're already syncing the view, so we can ignore any further requests.
+        ().pure[F]
+
+      case SyncMode.Block(_, _, _, lastSyncedViewNumber)
+          if lastSyncedViewNumber >= request.viewNumber =>
+        // We have already synced to a view that covers the state where the request was made.
+        ().pure[F]
+
+      case SyncMode.Block(_, _, shutdownBlockSync, _) =>
+        // 1. Switch to view sync mode
+        // 2. Cancel all outstanding block syncing
+        // 3. Sync to the latest Commit Q.C.
+        // 4. Switch back to block sync mode
+        for {
+          viewMode <- syncModeFactory.view
+          _        <- syncModeRef.set(viewMode)
+          _        <- shutdownBlockSync
+
+          status <- viewMode.synchronizer.sync
+          // TODO: Get the block, tell the application to sync the state.
+          _ <- syncPipe.send(SyncPipe.StatusResponse(status))
+
+          blockMode <- syncModeFactory.block(status.viewNumber)
+          _         <- syncModeRef.set(blockMode)
+        } yield ()
+    }
   }
 
   // TODO (PM-3132, PM-3133): Block validation.
@@ -221,7 +280,6 @@ object SyncService {
     // TODO (PM-3186): Add capacity as part of rate limiting.
     for {
       incomingFiberMap <- FiberMap[F, A#PKey]()
-      syncFiberMap     <- FiberMap[F, A#PKey]()
       rpcTracker <- Resource.liftF {
         RPCTracker[F, SyncMessage[A]](timeout)
       }
@@ -232,14 +290,62 @@ object SyncService {
         syncPipe,
         getState,
         incomingFiberMap,
-        syncFiberMap,
         rpcTracker
       )
-      blockSync <- Resource.liftF {
-        BlockSynchronizer[F, N, A](blockStorage, service.getBlock)
+
+      syncModeFactory = new SyncMode.Factory[F, N, A] {
+        override def block(viewNumber: ViewNumber) =
+          for {
+            (syncFiberMap, release) <- FiberMap[F, A#PKey]().allocated
+            blockSynchronizer <- BlockSynchronizer[F, N, A](
+              blockStorage,
+              service.getBlock
+            )
+            mode = SyncMode.Block(
+              blockSynchronizer,
+              syncFiberMap,
+              release,
+              viewNumber
+            )
+          } yield mode
+
+        override val view =
+          Sync[F]
+            .delay {
+              new ViewSynchronizer[F, A](federation, service.getStatus)
+            }
+            .map(SyncMode.View(_))
+
       }
-      viewSync = new ViewSynchronizer[F, A](federation, service.getStatus)
+
       _ <- Concurrent[F].background(service.processNetworkMessages)
-      _ <- Concurrent[F].background(service.processSyncPipe(blockSync))
+      _ <- Concurrent[F].background(service.processSyncPipe(syncModeFactory))
     } yield service
+
+  /** The `SyncService` can be in two modes: either we're in sync with the federation
+    * and downloading the odd missing block every now and then, or we are out of sync,
+    * in which case we need to ask everyone to find out what the current view number
+    * is, and then jump straight to the latest Commit Quorum Certificate.
+    *
+    * Our implementation assumes that this is always supported by the application.
+    */
+  sealed trait SyncMode[F[_], N, A <: Agreement]
+
+  object SyncMode {
+    case class Block[F[_], N, A <: Agreement](
+        synchronizer: BlockSynchronizer[F, N, A],
+        syncFiberMap: FiberMap[F, A#PKey],
+        syncFiberMapShutdown: F[Unit],
+        lastSyncedViewNumber: ViewNumber
+    ) extends SyncMode[F, N, A]
+
+    case class View[F[_], N, A <: Agreement](
+        synchronizer: ViewSynchronizer[F, A]
+    ) extends SyncMode[F, N, A]
+
+    trait Factory[F[_], N, A <: Agreement] {
+      def block(viewNumber: ViewNumber): F[Block[F, N, A]]
+      def view: F[View[F, N, A]]
+    }
+  }
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -1,6 +1,7 @@
 package io.iohk.metronome.hotstuff.service
 
 import cats.implicits._
+import cats.Parallel
 import cats.effect.{Sync, Resource, Concurrent, ContextShift, Timer}
 import cats.effect.concurrent.Ref
 import io.iohk.metronome.core.fibers.FiberMap
@@ -18,16 +19,20 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
 }
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 import io.iohk.metronome.hotstuff.service.pipes.SyncPipe
-import io.iohk.metronome.hotstuff.service.storage.BlockStorage
-import io.iohk.metronome.hotstuff.service.sync.BlockSynchronizer
+import io.iohk.metronome.hotstuff.service.storage.{
+  BlockStorage,
+  ViewStateStorage
+}
+import io.iohk.metronome.hotstuff.service.sync.{
+  BlockSynchronizer,
+  ViewSynchronizer
+}
 import io.iohk.metronome.hotstuff.service.tracing.SyncTracers
 import io.iohk.metronome.networking.ConnectionHandler
-import io.iohk.metronome.storage.KVStoreRunner
+import io.iohk.metronome.storage.{KVStoreRunner, KVStore}
 import scala.util.control.NonFatal
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
-import io.iohk.metronome.hotstuff.service.sync.ViewSynchronizer
-import cats.Parallel
 
 /** The `SyncService` handles the `SyncMessage`s coming from the network,
   * i.e. serving block and status requests, as well as receive responses
@@ -39,10 +44,11 @@ import cats.Parallel
   * The block and view synchronisation components will use this service
   * to send requests to the network.
   */
-class SyncService[F[_]: Concurrent: Parallel, N, A <: Agreement](
+class SyncService[F[_]: Concurrent, N, A <: Agreement: Block](
     publicKey: A#PKey,
     network: Network[F, A, SyncMessage[A]],
     blockStorage: BlockStorage[N, A],
+    viewStateStorage: ViewStateStorage[N, A],
     syncPipe: SyncPipe[F, A]#Right,
     getState: F[ProtocolState[A]],
     incomingFiberMap: FiberMap[F, A#PKey],
@@ -198,6 +204,7 @@ class SyncService[F[_]: Concurrent: Parallel, N, A <: Agreement](
       }
     } yield ()
 
+  /** Sync with the sender up to the High Q.C. it sent, then validate the prepared block. */
   private def handlePrepareRequest(
       syncModeRef: SyncModeRef,
       request: SyncPipe.PrepareRequest[A]
@@ -231,6 +238,10 @@ class SyncService[F[_]: Concurrent: Parallel, N, A <: Agreement](
     }
   }
 
+  /** Get the latest status of federation members, download the corresponding block
+    * and prune all existing block history, making the latest Commit Q.C. the new
+    * root in the block tree.
+    */
   private def handleStatusRequest(
       syncModeRef: SyncModeRef,
       syncModeFactory: SyncMode.Factory[F, N, A],
@@ -268,8 +279,10 @@ class SyncService[F[_]: Concurrent: Parallel, N, A <: Agreement](
               )
 
               // Prune the block store from earlier blocks that are no longer traversable.
+              _ <- fastForwardStorage(status, block)
 
-              // TODO (PM-3135): Tell the application to sync state of the block.
+              // Sync any application specific state, e.g. a ledger.
+              _ <- syncAppState(status.commitQC.blockHash)
 
               // Switch back to block sync mode
               _ <- syncModeRef.set(blockMode)
@@ -288,8 +301,45 @@ class SyncService[F[_]: Concurrent: Parallel, N, A <: Agreement](
     }
   }
 
+  /** Replace the state we have persisted with what we synced with the federation.
+    *
+    * Prunes old blocks, the Commit Q.C. will be the new root.
+    */
+  private def fastForwardStorage(status: Status[A], block: A#Block): F[Unit] = {
+    val blockHash = Block[A].blockHash(block)
+    assert(blockHash == status.commitQC.blockHash)
+
+    val query: KVStore[N, Unit] =
+      for {
+        viewState <- viewStateStorage.getBundle.lift
+        // Insert the new block.
+        _ <- blockStorage.put(block)
+
+        // Prune old data, but keep the new block.
+        ds <- blockStorage
+          .getDescendants(
+            viewState.rootBlockHash,
+            skip = Set(blockHash)
+          )
+          .lift
+        _ <- ds.traverse(blockStorage.deleteUnsafe(_))
+
+        // Considering the committed block as executed, we have its state already.
+        _ <- viewStateStorage.setLastExecutedBlockHash(blockHash)
+        _ <- viewStateStorage.setRootBlockHash(blockHash)
+        _ <- viewStateStorage.setViewNumber(status.viewNumber)
+        _ <- viewStateStorage.setQuorumCertificate(status.prepareQC)
+        _ <- viewStateStorage.setQuorumCertificate(status.commitQC)
+      } yield ()
+
+    storeRunner.runReadWrite(query)
+  }
+
   // TODO (PM-3132, PM-3133): Block validation.
-  private def validateBlock(block: A#Block): F[Boolean] = ???
+  private def validateBlock(block: A#Block): F[Boolean] = true.pure[F]
+
+  // TODO (PM-3135): Tell the application to sync state of the block.
+  private def syncAppState(blockHash: A#Hash): F[Unit] = ().pure[F]
 }
 
 object SyncService {
@@ -305,6 +355,7 @@ object SyncService {
       federation: Federation[A#PKey],
       network: Network[F, A, SyncMessage[A]],
       blockStorage: BlockStorage[N, A],
+      viewStateStorage: ViewStateStorage[N, A],
       syncPipe: SyncPipe[F, A]#Right,
       getState: F[ProtocolState[A]],
       timeout: FiniteDuration = 10.seconds
@@ -322,6 +373,7 @@ object SyncService {
         publicKey,
         network,
         blockStorage,
+        viewStateStorage,
         syncPipe,
         getState,
         incomingFiberMap,
@@ -331,14 +383,14 @@ object SyncService {
       syncModeFactory = new SyncMode.Factory[F, N, A] {
         override def block(viewNumber: ViewNumber) =
           for {
-            (syncFiberMap, syncFiberMapRelease) <- FiberMap[
-              F,
-              A#PKey
-            ]().allocated
+            (syncFiberMap, syncFiberMapRelease) <-
+              FiberMap[F, A#PKey]().allocated
+
             blockSynchronizer <- BlockSynchronizer[F, N, A](
               blockStorage,
               service.getBlock
             )
+
             mode = SyncMode.Block(
               blockSynchronizer,
               syncFiberMap,

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/messages/DuplexMessage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/messages/DuplexMessage.scala
@@ -6,7 +6,7 @@ import io.iohk.metronome.hotstuff.consensus.basic.Agreement
 /** Messages type to use in the networking layer if the use case has
   * application specific message types, e.g. ledger synchronisation,
   * not just the general BFT agreement (which could be enough if
-  * we need to execute all blocks to synchronise state).
+  * we need to execute all blocks to synchronize state).
   */
 sealed trait DuplexMessage[A <: Agreement, M]
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/pipes/SyncPipe.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/pipes/SyncPipe.scala
@@ -5,7 +5,10 @@ import io.iohk.metronome.core.Pipe
 import io.iohk.metronome.hotstuff.consensus.basic.Agreement
 import io.iohk.metronome.hotstuff.consensus.basic.Message
 
-object BlockSyncPipe {
+object SyncPipe {
+
+  sealed trait Request[A <: Agreement]
+  sealed trait Response[A <: Agreement]
 
   /** Request the synchronization component to download
     * any missing dependencies up to the High Q.C.,
@@ -19,21 +22,20 @@ object BlockSyncPipe {
     * while the one in the High Q.C. has gathered
     * a quorum from the federation.
     */
-  case class Request[A <: Agreement](
+  case class PrepareRequest[A <: Agreement](
       sender: A#PKey,
       prepare: Message.Prepare[A]
-  )
+  ) extends Request[A]
 
   /** Respond with the outcome of whether the
     * block we're being asked to prepare is
     * valid, according to the application rules.
     */
-  case class Response[A <: Agreement](
-      request: Request[A],
+  case class PrepareResponse[A <: Agreement](
+      request: PrepareRequest[A],
       isValid: Boolean
-  )
+  ) extends Response[A]
 
-  def apply[F[_]: Concurrent: ContextShift, A <: Agreement]
-      : F[BlockSyncPipe[F, A]] =
-    Pipe[F, BlockSyncPipe.Request[A], BlockSyncPipe.Response[A]]
+  def apply[F[_]: Concurrent: ContextShift, A <: Agreement]: F[SyncPipe[F, A]] =
+    Pipe[F, SyncPipe.Request[A], SyncPipe.Response[A]]
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/pipes/SyncPipe.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/pipes/SyncPipe.scala
@@ -2,13 +2,14 @@ package io.iohk.metronome.hotstuff.service.pipes
 
 import cats.effect.{Concurrent, ContextShift}
 import io.iohk.metronome.core.Pipe
-import io.iohk.metronome.hotstuff.consensus.basic.Agreement
-import io.iohk.metronome.hotstuff.consensus.basic.Message
+import io.iohk.metronome.hotstuff.consensus.ViewNumber
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, Message}
+import io.iohk.metronome.hotstuff.service.Status
 
 object SyncPipe {
 
-  sealed trait Request[A <: Agreement]
-  sealed trait Response[A <: Agreement]
+  sealed trait Request[+A <: Agreement]
+  sealed trait Response[+A <: Agreement]
 
   /** Request the synchronization component to download
     * any missing dependencies up to the High Q.C.,
@@ -34,6 +35,22 @@ object SyncPipe {
   case class PrepareResponse[A <: Agreement](
       request: PrepareRequest[A],
       isValid: Boolean
+  ) extends Response[A]
+
+  /** Request that the view state is synchronized with the whole federation,
+    * including downloading the block and state corresponding to the latest
+    * Commit Q.C.
+    *
+    * The eventual response should contain the new view status to be applied
+    * on the protocol state.
+    */
+  case class StatusRequest(viewNumber: ViewNumber) extends Request[Nothing]
+
+  /** Response with the new status to resume the protocol from, after the
+    * state has been synchronized up to the included Commit Q.C.
+    */
+  case class StatusResponse[A <: Agreement](
+      status: Status[A]
   ) extends Response[A]
 
   def apply[F[_]: Concurrent: ContextShift, A <: Agreement]: F[SyncPipe[F, A]] =

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/pipes/package.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/pipes/package.scala
@@ -6,6 +6,6 @@ import io.iohk.metronome.hotstuff.consensus.basic.Agreement
 package object pipes {
 
   /** Communication pipe with the block synchronization and validation component. */
-  type BlockSyncPipe[F[_], A <: Agreement] =
-    Pipe[F, BlockSyncPipe.Request[A], BlockSyncPipe.Response[A]]
+  type SyncPipe[F[_], A <: Agreement] =
+    Pipe[F, SyncPipe.Request[A], SyncPipe.Response[A]]
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
@@ -3,7 +3,7 @@ package io.iohk.metronome.hotstuff.service.sync
 import cats._
 import cats.implicits._
 import cats.effect.{Timer, Sync}
-import cats.data.NonEmptyVector
+import cats.data.NonEmptySeq
 import io.iohk.metronome.core.Validated
 import io.iohk.metronome.hotstuff.consensus.{Federation, ViewNumber}
 import io.iohk.metronome.hotstuff.consensus.basic.{
@@ -45,7 +45,7 @@ class ViewSynchronizer[F[_]: Sync: Timer: Parallel, A <: Agreement: Signing](
           .statusPoll(federation.publicKeys -> maybeStatuses)
           .as(maybeStatuses.flatten)
       }
-      .map(NonEmptyVector.fromVector)
+      .map(NonEmptySeq.fromSeq)
       .flatMap {
         case Some(statuses) if statuses.size >= federation.quorumSize =>
           aggregateStatus(statuses).pure[F]
@@ -133,7 +133,7 @@ object ViewSynchronizer {
   type GetStatus[F[_], A <: Agreement] = A#PKey => F[Option[Status[A]]]
 
   def aggregateStatus[A <: Agreement](
-      statuses: NonEmptyVector[Status[A]]
+      statuses: NonEmptySeq[Status[A]]
   ): Status[A] = {
     val prepareQC = statuses.map(_.prepareQC).maximumBy(_.viewNumber)
     val commitQC  = statuses.map(_.commitQC).maximumBy(_.viewNumber)
@@ -146,6 +146,6 @@ object ViewSynchronizer {
     )
   }
 
-  def median[T: Order](xs: NonEmptyVector[T]): T =
+  def median[T: Order](xs: NonEmptySeq[T]): T =
     xs.sorted.getUnsafe((xs.size / 2).toInt)
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
@@ -1,0 +1,69 @@
+package io.iohk.metronome.hotstuff.service.sync
+
+import cats._
+import cats.implicits._
+import cats.effect.{Timer, Sync}
+import io.iohk.metronome.hotstuff.consensus.Federation
+import io.iohk.metronome.hotstuff.consensus.basic.Agreement
+import io.iohk.metronome.hotstuff.service.Status
+import io.iohk.metronome.hotstuff.service.tracing.SyncTracers
+import scala.concurrent.duration._
+import cats.data.NonEmptyVector
+
+/** The job of the `ViewSynchronizer` is to ask the other federation members
+  * what their status is and figure out a view number we should be using.
+  * This is something we must do after startup, or if we have for some reason
+  * fallen out of sync with the rest of the federation.
+  */
+class ViewSynchronizer[F[_]: Sync: Timer: Parallel, A <: Agreement](
+    federation: Federation[A#PKey],
+    getStatus: ViewSynchronizer.GetStatus[F, A],
+    retryTimeout: FiniteDuration = 5.seconds
+)(implicit tracers: SyncTracers[F, A]) {
+  import ViewSynchronizer.aggregateStatus
+
+  /** Poll the federation members for the current status until we have gathered
+    * enough to make a decision, i.e. we have a quorum.
+    *
+    * Pick the highest Quorum Certificates from the gathered responses, but be
+    * more careful with he view number as these can be disingenuous.
+    *
+    * Try again until in one round we can gather all statuses from everyone.
+    */
+  def sync: F[Status[A]] = {
+    federation.publicKeys.toVector
+      .parTraverse(getStatus)
+      .flatMap { maybeStatuses =>
+        tracers
+          .statusPoll(federation.publicKeys -> maybeStatuses)
+          .as(maybeStatuses.flatten)
+      }
+      .map(NonEmptyVector.fromVector)
+      .flatMap {
+        case Some(statuses) if statuses.size >= federation.quorumSize =>
+          aggregateStatus(statuses).pure[F]
+
+        case _ =>
+          // We traced all responses, so we can detect if we're in an endless loop.
+          Timer[F].sleep(retryTimeout) >> sync
+      }
+  }
+}
+
+object ViewSynchronizer {
+
+  /** Send a network request to get the status of a replica. */
+  type GetStatus[F[_], A <: Agreement] = A#PKey => F[Option[Status[A]]]
+
+  def aggregateStatus[A <: Agreement](
+      statuses: NonEmptyVector[Status[A]]
+  ): Status[A] =
+    Status(
+      viewNumber = median(statuses.map(_.viewNumber)),
+      prepareQC = statuses.map(_.prepareQC).maximumBy(_.viewNumber),
+      commitQC = statuses.map(_.commitQC).maximumBy(_.viewNumber)
+    )
+
+  def median[T: Order](xs: NonEmptyVector[T]): T =
+    xs.sorted.getUnsafe((xs.size / 2).toInt)
+}

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
@@ -3,7 +3,7 @@ package io.iohk.metronome.hotstuff.service.sync
 import cats._
 import cats.implicits._
 import cats.effect.{Timer, Sync}
-import cats.data.NonEmptySeq
+import cats.data.{NonEmptySeq, NonEmptyVector}
 import io.iohk.metronome.core.Validated
 import io.iohk.metronome.hotstuff.consensus.{Federation, ViewNumber}
 import io.iohk.metronome.hotstuff.consensus.basic.{
@@ -54,14 +54,11 @@ class ViewSynchronizer[F[_]: Sync: Timer: Parallel, A <: Agreement: Signing](
           val statuses = statusMap.values.toList
           val status   = aggregateStatus(NonEmptySeq.fromSeqUnsafe(statuses))
 
-          val commitSources = statusMap.collect {
-            case (memberKey, memberStatus)
-                if memberStatus.commitQC == status.commitQC =>
-              memberKey
-          }.toList
+          // Returning everyone who responded so we always have a quorum sized set to talk to.
+          val sources =
+            NonEmptyVector.fromVectorUnsafe(statusMap.keySet.toVector)
 
-          FederationStatus(status, NonEmptySeq.fromSeqUnsafe(commitSources))
-            .pure[F]
+          FederationStatus(status, sources).pure[F]
 
         case _ =>
           // We traced all responses, so we can detect if we're in an endless loop.
@@ -165,6 +162,6 @@ object ViewSynchronizer {
   /** The final status coupled with the federation members that can serve the data. */
   case class FederationStatus[A <: Agreement](
       status: Status[A],
-      commitSources: NonEmptySeq[A#PKey]
+      sources: NonEmptyVector[A#PKey]
   )
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -1,5 +1,6 @@
 package io.iohk.metronome.hotstuff.service.tracing
 
+import io.iohk.metronome.core.Validated
 import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, ProtocolError}
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 import io.iohk.metronome.hotstuff.service.Status
@@ -32,11 +33,12 @@ object SyncEvent {
     * Only contains results for federation members that responded within the timeout.
     */
   case class StatusPoll[A <: Agreement](
-      statuses: Map[A#PKey, Status[A]]
+      statuses: Map[A#PKey, Validated[Status[A]]]
   ) extends SyncEvent[A]
 
-  /** A federation members sent a `Status` with an invalid Q.C. */
-  case class InvalidStatusQuorumCertificate[A <: Agreement](
+  /** A federation members sent a `Status` with invalid content. */
+  case class InvalidStatus[A <: Agreement](
+      status: Status[A],
       error: ProtocolError.InvalidQuorumCertificate[A]
   ) extends SyncEvent[A]
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -2,6 +2,7 @@ package io.iohk.metronome.hotstuff.service.tracing
 
 import io.iohk.metronome.hotstuff.consensus.basic.Agreement
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
+import io.iohk.metronome.hotstuff.service.Status
 
 sealed trait SyncEvent[+A <: Agreement]
 
@@ -24,6 +25,13 @@ object SyncEvent {
   case class ResponseIgnored[A <: Agreement](
       sender: A#PKey,
       response: SyncMessage[A] with SyncMessage.Response
+  ) extends SyncEvent[A]
+
+  /** Performed a poll for `Status` across the federation. Federation members that
+    * didn't respond in time are represented by `None` in the results.
+    */
+  case class StatusPoll[A <: Agreement](
+      statuses: Map[A#PKey, Option[Status[A]]]
   ) extends SyncEvent[A]
 
   /** An unexpected error in one of the background tasks. */

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -39,7 +39,8 @@ object SyncEvent {
   /** A federation members sent a `Status` with invalid content. */
   case class InvalidStatus[A <: Agreement](
       status: Status[A],
-      error: ProtocolError.InvalidQuorumCertificate[A]
+      error: ProtocolError.InvalidQuorumCertificate[A],
+      hint: String
   ) extends SyncEvent[A]
 
   /** An unexpected error in one of the background tasks. */

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
@@ -29,7 +29,7 @@ object SyncTracers {
     (IndexedSeq[A#PKey], IndexedSeq[Option[Validated[Status[A]]]])
 
   type StatusError[A <: Agreement] =
-    (Status[A], ProtocolError.InvalidQuorumCertificate[A])
+    (Status[A], ProtocolError.InvalidQuorumCertificate[A], String)
 
   def apply[F[_], A <: Agreement](
       tracer: Tracer[F, SyncEvent[A]]
@@ -52,9 +52,10 @@ object SyncTracers {
             }
           }
         },
-      invalidStatus = tracer.contramap[StatusError[A]] { case (status, error) =>
-        InvalidStatus(status, error)
-      },
+      invalidStatus =
+        tracer.contramap[StatusError[A]] { case (status, error, hint) =>
+          InvalidStatus(status, error, hint)
+        },
       error = tracer.contramap[Throwable](Error(_))
     )
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
@@ -2,7 +2,7 @@ package io.iohk.metronome.hotstuff.service.tracing
 
 import cats.implicits._
 import io.iohk.metronome.tracer.Tracer
-import io.iohk.metronome.hotstuff.consensus.basic.Agreement
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, ProtocolError}
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 import io.iohk.metronome.hotstuff.service.Status
 
@@ -11,6 +11,7 @@ case class SyncTracers[F[_], A <: Agreement](
     requestTimeout: Tracer[F, SyncTracers.Request[A]],
     responseIgnored: Tracer[F, SyncTracers.Response[A]],
     statusPoll: Tracer[F, SyncTracers.Statuses[A]],
+    invalidQC: Tracer[F, ProtocolError.InvalidQuorumCertificate[A]],
     error: Tracer[F, Throwable]
 )
 
@@ -41,8 +42,16 @@ object SyncTracers {
         },
       statusPoll = tracer
         .contramap[Statuses[A]] { case (publicKeys, maybeStatuses) =>
-          StatusPoll[A]((publicKeys zip maybeStatuses).toMap)
+          StatusPoll[A] {
+            (publicKeys zip maybeStatuses).toMap.collect {
+              case (key, Some(status)) => key -> status
+            }
+          }
         },
+      invalidQC = tracer
+        .contramap[ProtocolError.InvalidQuorumCertificate[A]](
+          InvalidStatusQuorumCertificate(_)
+        ),
       error = tracer.contramap[Throwable](Error(_))
     )
 }

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -288,7 +288,7 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
       responseCounter <- fixture.responseCounterRef.get
     } yield {
       val statusProps = status match {
-        case Right(FederationStatus(status, commitSources)) =>
+        case Right(FederationStatus(status, sources)) =>
           "status" |: all(
             "quorum" |: hasQuorum,
             "reports polls each round" |:
@@ -298,7 +298,7 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
               pollSizes.init.forall(_ < quorumSize),
             "reports all invalid" |:
               invalidEventCount == invalidResponseCount,
-            "returns sources" |: commitSources.toSeq.size >= quorumSize
+            "returns sources" |: sources.toVector.size >= quorumSize
           )
 
         case Left(ex: TimeoutException) =>

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -32,6 +32,7 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
     genInitialState,
     genHash
   }
+  import ViewSynchronizer.FederationStatus
 
   /** Projected responses in each round from every federation member. */
   type Responses = Vector[Map[TestAgreement.PKey, TestResponse]]
@@ -287,7 +288,7 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
       responseCounter <- fixture.responseCounterRef.get
     } yield {
       val statusProps = status match {
-        case Right(status) =>
+        case Right(FederationStatus(status, commitSources)) =>
           "status" |: all(
             "quorum" |: hasQuorum,
             "reports polls each round" |:
@@ -296,7 +297,8 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
               pollSizes.last >= quorumSize &&
               pollSizes.init.forall(_ < quorumSize),
             "reports all invalid" |:
-              invalidEventCount == invalidResponseCount
+              invalidEventCount == invalidResponseCount,
+            "returns sources" |: commitSources.toSeq.size >= quorumSize
           )
 
         case Left(ex: TimeoutException) =>

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -1,0 +1,307 @@
+package io.iohk.metronome.hotstuff.service.sync
+
+import cats.effect.concurrent.Ref
+import io.iohk.metronome.hotstuff.consensus.{
+  Federation,
+  LeaderSelection,
+  ViewNumber
+}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  ProtocolStateCommands,
+  QuorumCertificate,
+  Phase,
+  Signing
+}
+import io.iohk.metronome.hotstuff.service.Status
+import io.iohk.metronome.hotstuff.service.tracing.{SyncTracers, SyncEvent}
+import io.iohk.metronome.tracer.Tracer
+import monix.eval.Task
+import monix.execution.schedulers.TestScheduler
+import org.scalacheck.{Arbitrary, Properties, Gen}
+import org.scalacheck.Prop.{forAll, propBoolean, all}
+import scala.concurrent.duration._
+import java.util.concurrent.TimeoutException
+
+object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
+  import ProtocolStateCommands.{
+    TestAgreement,
+    mockSigning,
+    mockSigningKey,
+    genInitialState,
+    genHash
+  }
+
+  /** Projected responses in each round from every federation member. */
+  type Responses = Vector[Map[TestAgreement.PKey, TestResponse]]
+
+  case class TestFixture(
+      rounds: Int,
+      federation: Federation[TestAgreement.PKey],
+      responses: Responses
+  ) {
+    val responseCounterRef =
+      Ref.unsafe[Task, Map[TestAgreement.PKey, Int]](
+        federation.publicKeys.map(_ -> 0).toMap
+      )
+
+    val syncEventsRef =
+      Ref.unsafe[Task, Vector[SyncEvent[TestAgreement]]](Vector.empty)
+
+    private val syncEventTracer =
+      Tracer.instance[Task, SyncEvent[TestAgreement]] { event =>
+        syncEventsRef.update(_ :+ event)
+      }
+
+    implicit val syncTracers: SyncTracers[Task, TestAgreement] =
+      SyncTracers(syncEventTracer)
+
+    def getStatus(
+        publicKey: TestAgreement.PKey
+    ): Task[Option[Status[TestAgreement]]] =
+      for {
+        round <- responseCounterRef.modify { responseCounter =>
+          val count = responseCounter(publicKey)
+          responseCounter.updated(publicKey, count + 1) -> count
+        }
+        result =
+          if (round >= responses.size) None
+          else
+            responses(round)(publicKey) match {
+              case TestResponse.Timeout               => None
+              case TestResponse.InvalidStatus(status) => Some(status)
+              case TestResponse.ValidStatus(status)   => Some(status)
+            }
+      } yield result
+  }
+
+  object TestFixture {
+    implicit val leaderSelection = LeaderSelection.RoundRobin
+
+    implicit val arb: Arbitrary[TestFixture] = Arbitrary {
+      for {
+        state <- genInitialState
+        federation = Federation(state.federation, state.f).getOrElse(
+          sys.error("Invalid federation.")
+        )
+        byzantineCount <- Gen.choose(0, state.f)
+        byzantines = federation.publicKeys.take(byzantineCount).toSet
+        rounds <- Gen.posNum[Int]
+        genesisQC = state.newViewsHighQC
+        responses <- genResponses(rounds, federation, byzantines, genesisQC)
+      } yield TestFixture(
+        rounds,
+        federation,
+        responses
+      )
+    }
+  }
+
+  sealed trait TestResponse
+  object TestResponse {
+    case object Timeout                                     extends TestResponse
+    case class ValidStatus(status: Status[TestAgreement])   extends TestResponse
+    case class InvalidStatus(status: Status[TestAgreement]) extends TestResponse
+  }
+
+  /** Generate a series of hypothetical responses projected from an idealized consensus process. */
+  def genResponses(
+      rounds: Int,
+      federation: Federation[TestAgreement.PKey],
+      byzantines: Set[TestAgreement.PKey],
+      genesisQC: QuorumCertificate[TestAgreement]
+  ): Gen[Responses] = {
+
+    def genPrepareQC(qc: QuorumCertificate[TestAgreement]) =
+      for {
+        quorumKeys <- Gen
+          .pick(federation.quorumSize, federation.publicKeys)
+          .map(_.toVector)
+        blockHash <- genHash
+        viewNumber = qc.viewNumber.next
+        partialSigs = quorumKeys.map { publicKey =>
+          val signingKey = mockSigningKey(publicKey)
+          Signing[TestAgreement].sign(
+            signingKey,
+            Phase.Prepare,
+            viewNumber,
+            blockHash
+          )
+        }
+        groupSig = mockSigning.combine(partialSigs)
+      } yield QuorumCertificate[TestAgreement](
+        Phase.Prepare,
+        viewNumber,
+        blockHash,
+        groupSig
+      )
+
+    def genCommitQC(qc: QuorumCertificate[TestAgreement]) =
+      for {
+        quorumKeys <- Gen
+          .pick(federation.quorumSize, federation.publicKeys)
+          .map(_.toVector)
+        blockHash  = qc.blockHash
+        viewNumber = qc.viewNumber
+        partialSigs = quorumKeys.map { publicKey =>
+          val signingKey = mockSigningKey(publicKey)
+          Signing[TestAgreement].sign(
+            signingKey,
+            Phase.Commit,
+            viewNumber,
+            blockHash
+          )
+        }
+        groupSig = mockSigning.combine(partialSigs)
+      } yield QuorumCertificate[TestAgreement](
+        Phase.Commit,
+        viewNumber,
+        blockHash,
+        groupSig
+      )
+
+    def genInvalid(status: Status[TestAgreement]) = {
+      def delay(invalid: => Status[TestAgreement]) =
+        Gen.delay(Gen.const(invalid))
+      Gen.oneOf(
+        delay(status.copy(viewNumber = status.prepareQC.viewNumber.prev)),
+        delay(status.copy(prepareQC = status.commitQC)),
+        delay(status.copy(commitQC = status.prepareQC)),
+        delay(
+          status.copy(commitQC =
+            status.commitQC.copy[TestAgreement](signature =
+              status.commitQC.signature
+                .copy(sig = status.commitQC.signature.sig.map(_ + 1))
+            )
+          )
+        ).filter(_.commitQC.viewNumber > 0)
+      )
+    }
+
+    def loop(
+        round: Int,
+        prepareQC: QuorumCertificate[TestAgreement],
+        commitQC: QuorumCertificate[TestAgreement],
+        accum: Responses
+    ): Gen[Responses] =
+      if (round == rounds) Gen.const(accum)
+      else {
+        val genRound = for {
+          nextPrepareQC <- Gen.oneOf(
+            Gen.const(prepareQC),
+            genPrepareQC(prepareQC)
+          )
+          nextCommitQC <- Gen.oneOf(
+            Gen.const(commitQC),
+            genCommitQC(prepareQC).filter(_.viewNumber > 0),
+            genCommitQC(nextPrepareQC).filter(_.viewNumber > 0)
+          )
+          status = Status(ViewNumber(round + 1), nextPrepareQC, nextCommitQC)
+          responses <- Gen.sequence[Vector[TestResponse], TestResponse] {
+            federation.publicKeys.map { publicKey =>
+              if (byzantines.contains(publicKey)) {
+                Gen.frequency(
+                  3 -> Gen.const(TestResponse.Timeout),
+                  2 -> Gen.const(TestResponse.ValidStatus(status)),
+                  5 -> genInvalid(status).map(TestResponse.InvalidStatus(_))
+                )
+              } else {
+                Gen.frequency(
+                  1 -> TestResponse.Timeout,
+                  4 -> TestResponse.ValidStatus(status)
+                )
+              }
+            }
+          }
+          responseMap = (federation.publicKeys zip responses).toMap
+        } yield (nextPrepareQC, nextCommitQC, responseMap)
+
+        genRound.flatMap { case (prepareQC, commitQC, responseMap) =>
+          loop(round + 1, prepareQC, commitQC, accum :+ responseMap)
+        }
+      }
+
+    loop(
+      0,
+      genesisQC,
+      genesisQC.copy[TestAgreement](phase = Phase.Commit),
+      Vector.empty
+    )
+  }
+
+  property("sync") = forAll { (fixture: TestFixture) =>
+    implicit val scheduler = TestScheduler()
+    import fixture.syncTracers
+
+    val retryTimeout = 5.seconds
+    val syncTimeout  = fixture.rounds * retryTimeout * 2
+    val synchronizer = new ViewSynchronizer[Task, TestAgreement](
+      federation = fixture.federation,
+      getStatus = fixture.getStatus,
+      retryTimeout = retryTimeout
+    )
+
+    val test = for {
+      status <- synchronizer.sync.timeout(syncTimeout).attempt
+      events <- fixture.syncEventsRef.get
+
+      quorumSize = fixture.federation.quorumSize
+
+      indexOfQuorum = fixture.responses.indexWhere { responseMap =>
+        responseMap.values.collect { case TestResponse.ValidStatus(_) =>
+        }.size >= quorumSize
+      }
+      hasQuorum = indexOfQuorum >= 0
+
+      invalidResponseCount = {
+        val responses =
+          if (hasQuorum) fixture.responses.take(indexOfQuorum + 1)
+          else fixture.responses
+        responses
+          .flatMap(_.values)
+          .collect { case TestResponse.InvalidStatus(_) =>
+          }
+          .size
+      }
+
+      invalidEventCount = {
+        events.collect { case x: SyncEvent.InvalidStatus[_] =>
+        }.size
+      }
+
+      pollSizes = events.collect { case SyncEvent.StatusPoll(statuses) =>
+        statuses.size
+      }
+    } yield {
+      status match {
+        case Right(status) =>
+          "status" |: all(
+            "quorum" |: hasQuorum,
+            "reports polls each round" |:
+              pollSizes.size == indexOfQuorum + 1,
+            "stop at the first quorum" |:
+              pollSizes.last >= quorumSize &&
+              pollSizes.init.forall(_ < quorumSize),
+            "reports all invalid" |:
+              invalidEventCount == invalidResponseCount
+          )
+
+        case Left(ex: TimeoutException) =>
+          "timeout" |: all(
+            "no quorum" |: !hasQuorum,
+            "empty polls" |: pollSizes.forall(_ < quorumSize),
+            "keeps polling" |: pollSizes.size >= fixture.rounds,
+            "reports all invalid" |: invalidEventCount == invalidResponseCount
+          )
+
+        case Left(ex) =>
+          ex.getMessage |: false
+      }
+    }
+
+    val testFuture = test.runToFuture
+
+    scheduler.tick(syncTimeout)
+
+    testFuture.value.get.get
+  }
+}

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -315,7 +315,7 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
 
       all(
         statusProps,
-        "poll everyone in each round" |: responseCounter.values.toList.distinct.size == 1
+        "poll everyone in each round" |: responseCounter.values.toList.distinct.size <= 2 // Due to timing some could get an extra.
       )
     }
 


### PR DESCRIPTION
Added a `ViewSynchronizer` component that asks all federation members for their current `Status` and determines the best values to adopt: it picks the highest Prepare and Commit Quorum Certificates, and the median View Number. The former have signatures to prove their validity, but the latter could be games by adversarial actors, hence not using the highest value. Multiple rounds of peers trying to sync with each other and picking the median should make them converge in the end.

TODO:
- [x] Validate signature
- [x] Tests
- [x] Wire into the SyncService
- [ ] ConsensusService to determine when to kick off view synchronisation
- [x] ConsensusService to adopt the new view