### PR TITLE
PM-3063: View synchronisation (Part 1)

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -252,7 +252,10 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
           hotstuff.forensics
         )
 
-      object test extends TestModule
+      object test extends TestModule {
+        override def moduleDeps: Seq[JavaModule] =
+          super.moduleDeps ++ Seq(hotstuff.consensus.test)
+      }
     }
   }
 

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/Federation.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/Federation.scala
@@ -23,7 +23,7 @@ package io.iohk.metronome.hotstuff.consensus
   *
   * Extra: The above two inequalities `(n+f)/2 < q <= n-f`, lead to the constraint: `f < n/3`, or `n >= 3*f+1`.
   */
-abstract case class Federation[PKey](
+abstract case class Federation[PKey] private (
     publicKeys: IndexedSeq[PKey],
     // Maximum number of Byzantine nodes.
     maxFaulty: Int

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/ViewNumber.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/ViewNumber.scala
@@ -1,6 +1,7 @@
 package io.iohk.metronome.hotstuff.consensus
 
 import io.iohk.metronome.core.Tagger
+import cats.kernel.Order
 
 object ViewNumber extends Tagger[Long] {
   implicit class Ops(val vn: ViewNumber) extends AnyVal {
@@ -10,4 +11,7 @@ object ViewNumber extends Tagger[Long] {
 
   implicit val ord: Ordering[ViewNumber] =
     Ordering.by(identity[Long])
+
+  implicit val order: Order[ViewNumber] =
+    Order.fromOrdering(ord)
 }

--- a/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
+++ b/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
@@ -313,7 +313,8 @@ object ProtocolStateCommands extends Commands {
         genLazy(
           qc.copy[TestAgreement](blockHash = invalidateHash(qc.blockHash))
         ),
-        genLazy(qc.copy[TestAgreement](phase = nextVoting(qc.phase))),
+        genLazy(qc.copy[TestAgreement](phase = nextVoting(qc.phase)))
+          .suchThat(_.blockHash != genesisQC.blockHash),
         genLazy(
           qc.copy[TestAgreement](viewNumber =
             invalidateViewNumber(qc.viewNumber)

--- a/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
+++ b/metronome/hotstuff/consensus/test/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
@@ -14,9 +14,9 @@ import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.util.{Try, Failure, Success}
 
-object HotStuffProtocolProps extends Properties("Basic HotStuff") {
+object ProtocolStateProps extends Properties("Basic HotStuff") {
 
-  property("protocol") = HotStuffProtocolCommands.property()
+  property("protocol") = ProtocolStateCommands.property()
 
 }
 
@@ -26,7 +26,7 @@ object HotStuffProtocolProps extends Properties("Basic HotStuff") {
   * and invalid commands using `genCommand`. Each `Command`, has its individual post-condition
   * check comparing the model state to the actual protocol results.
   */
-object HotStuffProtocolCommands extends Commands {
+object ProtocolStateCommands extends Commands {
 
   case class TestBlock(blockHash: Int, parentBlockHash: Int, command: String)
 
@@ -71,12 +71,10 @@ object HotStuffProtocolCommands extends Commands {
         (phase, viewNumber, blockHash).hashCode
 
       private def isGenesis(
-          phase: VotingPhase,
           viewNumber: ViewNumber,
           blockHash: TestAgreement.Hash
       ): Boolean =
-        phase == genesisQC.phase &&
-          viewNumber == genesisQC.viewNumber &&
+        viewNumber == genesisQC.viewNumber &&
           blockHash == genesisQC.blockHash
 
       private def sign(
@@ -125,7 +123,7 @@ object HotStuffProtocolCommands extends Commands {
           viewNumber: ViewNumber,
           blockHash: TestAgreement.Hash
       ): Boolean = {
-        if (isGenesis(phase, viewNumber, blockHash)) {
+        if (isGenesis(viewNumber, blockHash)) {
           signature.sig.isEmpty
         } else {
           val h = hash(phase, viewNumber, blockHash)

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
@@ -1,9 +1,7 @@
 package io.iohk.metronome.hotstuff.service
 
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
-import io.iohk.metronome.hotstuff.consensus.basic.Agreement
-import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
-import io.iohk.metronome.hotstuff.consensus.basic.Phase
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
 
 /** Status has all the fields necessary for nodes to sync with each other.
   *
@@ -14,7 +12,4 @@ case class Status[A <: Agreement](
     viewNumber: ViewNumber,
     prepareQC: QuorumCertificate[A],
     commitQC: QuorumCertificate[A]
-) {
-  require(prepareQC.phase == Phase.Prepare)
-  require(commitQC.phase == Phase.Commit)
-}
+)

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
@@ -3,6 +3,7 @@ package io.iohk.metronome.hotstuff.service
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
 import io.iohk.metronome.hotstuff.consensus.basic.Agreement
 import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import io.iohk.metronome.hotstuff.consensus.basic.Phase
 
 /** Status has all the fields necessary for nodes to sync with each other.
   *
@@ -13,4 +14,7 @@ case class Status[A <: Agreement](
     viewNumber: ViewNumber,
     prepareQC: QuorumCertificate[A],
     commitQC: QuorumCertificate[A]
-)
+) {
+  require(prepareQC.phase == Phase.Prepare)
+  require(commitQC.phase == Phase.Commit)
+}

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
@@ -3,7 +3,7 @@ package io.iohk.metronome.hotstuff.service.sync
 import cats._
 import cats.implicits._
 import cats.effect.{Timer, Sync}
-import cats.data.NonEmptyVector
+import cats.data.NonEmptySeq
 import io.iohk.metronome.core.Validated
 import io.iohk.metronome.hotstuff.consensus.{Federation, ViewNumber}
 import io.iohk.metronome.hotstuff.consensus.basic.{
@@ -45,7 +45,7 @@ class ViewSynchronizer[F[_]: Sync: Timer: Parallel, A <: Agreement: Signing](
           .statusPoll(federation.publicKeys -> maybeStatuses)
           .as(maybeStatuses.flatten)
       }
-      .map(NonEmptyVector.fromVector)
+      .map(NonEmptySeq.fromSeq)
       .flatMap {
         case Some(statuses) if statuses.size >= federation.quorumSize =>
           aggregateStatus(statuses).pure[F]
@@ -133,7 +133,7 @@ object ViewSynchronizer {
   type GetStatus[F[_], A <: Agreement] = A#PKey => F[Option[Status[A]]]
 
   def aggregateStatus[A <: Agreement](
-      statuses: NonEmptyVector[Status[A]]
+      statuses: NonEmptySeq[Status[A]]
   ): Status[A] = {
     val prepareQC = statuses.map(_.prepareQC).maximumBy(_.viewNumber)
     val commitQC  = statuses.map(_.commitQC).maximumBy(_.viewNumber)
@@ -146,6 +146,6 @@ object ViewSynchronizer {
     )
   }
 
-  def median[T: Order](xs: NonEmptyVector[T]): T =
+  def median[T: Order](xs: NonEmptySeq[T]): T =
     xs.sorted.getUnsafe((xs.size / 2).toInt)
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
@@ -1,0 +1,69 @@
+package io.iohk.metronome.hotstuff.service.sync
+
+import cats._
+import cats.implicits._
+import cats.effect.{Timer, Sync}
+import io.iohk.metronome.hotstuff.consensus.Federation
+import io.iohk.metronome.hotstuff.consensus.basic.Agreement
+import io.iohk.metronome.hotstuff.service.Status
+import io.iohk.metronome.hotstuff.service.tracing.SyncTracers
+import scala.concurrent.duration._
+import cats.data.NonEmptyVector
+
+/** The job of the `ViewSynchronizer` is to ask the other federation members
+  * what their status is and figure out a view number we should be using.
+  * This is something we must do after startup, or if we have for some reason
+  * fallen out of sync with the rest of the federation.
+  */
+class ViewSynchronizer[F[_]: Sync: Timer: Parallel, A <: Agreement](
+    federation: Federation[A#PKey],
+    getStatus: ViewSynchronizer.GetStatus[F, A],
+    retryTimeout: FiniteDuration = 5.seconds
+)(implicit tracers: SyncTracers[F, A]) {
+  import ViewSynchronizer.aggregateStatus
+
+  /** Poll the federation members for the current status until we have gathered
+    * enough to make a decision, i.e. we have a quorum.
+    *
+    * Pick the highest Quorum Certificates from the gathered responses, but be
+    * more careful with he view number as these can be disingenuous.
+    *
+    * Try again until in one round we can gather all statuses from everyone.
+    */
+  def sync: F[Status[A]] = {
+    federation.publicKeys.toVector
+      .parTraverse(getStatus)
+      .flatMap { maybeStatuses =>
+        tracers
+          .statusPoll(federation.publicKeys -> maybeStatuses)
+          .as(maybeStatuses.flatten)
+      }
+      .map(NonEmptyVector.fromVector)
+      .flatMap {
+        case Some(statuses) if statuses.size >= federation.quorumSize =>
+          aggregateStatus(statuses).pure[F]
+
+        case _ =>
+          // We traced all responses, so we can detect if we're in an endless loop.
+          Timer[F].sleep(retryTimeout) >> sync
+      }
+  }
+}
+
+object ViewSynchronizer {
+
+  /** Send a network request to get the status of a replica. */
+  type GetStatus[F[_], A <: Agreement] = A#PKey => F[Option[Status[A]]]
+
+  def aggregateStatus[A <: Agreement](
+      statuses: NonEmptyVector[Status[A]]
+  ): Status[A] =
+    Status(
+      viewNumber = median(statuses.map(_.viewNumber)),
+      prepareQC = statuses.map(_.prepareQC).maximumBy(_.viewNumber),
+      commitQC = statuses.map(_.commitQC).maximumBy(_.viewNumber)
+    )
+
+  def median[T: Order](xs: NonEmptyVector[T]): T =
+    xs.sorted.getUnsafe((xs.size / 2).toInt)
+}

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -40,7 +40,8 @@ object SyncEvent {
   /** A federation members sent a `Status` with invalid content. */
   case class InvalidStatus[A <: Agreement](
       status: Status[A],
-      error: ProtocolError.InvalidQuorumCertificate[A]
+      error: ProtocolError.InvalidQuorumCertificate[A],
+      hint: String
   ) extends SyncEvent[A]
 
   /** An unexpected error in one of the background tasks. */

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -1,8 +1,9 @@
 package io.iohk.metronome.hotstuff.service.tracing
 
-import io.iohk.metronome.hotstuff.consensus.basic.Agreement
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, ProtocolError}
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 import io.iohk.metronome.hotstuff.service.Status
+import io.iohk.metronome.hotstuff.consensus.basic.ProtocolError
 
 sealed trait SyncEvent[+A <: Agreement]
 
@@ -28,11 +29,16 @@ object SyncEvent {
       maybeError: Option[Throwable]
   ) extends SyncEvent[A]
 
-  /** Performed a poll for `Status` across the federation. Federation members that
-    * didn't respond in time are represented by `None` in the results.
+  /** Performed a poll for `Status` across the federation.
+    * Only contains results for federation members that responded within the timeout.
     */
   case class StatusPoll[A <: Agreement](
-      statuses: Map[A#PKey, Option[Status[A]]]
+      statuses: Map[A#PKey, Status[A]]
+  ) extends SyncEvent[A]
+
+  /** A federation members sent a `Status` with an invalid Q.C. */
+  case class InvalidStatusQuorumCertificate[A <: Agreement](
+      error: ProtocolError.InvalidQuorumCertificate[A]
   ) extends SyncEvent[A]
 
   /** An unexpected error in one of the background tasks. */

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -1,5 +1,6 @@
 package io.iohk.metronome.hotstuff.service.tracing
 
+import io.iohk.metronome.core.Validated
 import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, ProtocolError}
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 import io.iohk.metronome.hotstuff.service.Status
@@ -33,11 +34,12 @@ object SyncEvent {
     * Only contains results for federation members that responded within the timeout.
     */
   case class StatusPoll[A <: Agreement](
-      statuses: Map[A#PKey, Status[A]]
+      statuses: Map[A#PKey, Validated[Status[A]]]
   ) extends SyncEvent[A]
 
-  /** A federation members sent a `Status` with an invalid Q.C. */
-  case class InvalidStatusQuorumCertificate[A <: Agreement](
+  /** A federation members sent a `Status` with invalid content. */
+  case class InvalidStatus[A <: Agreement](
+      status: Status[A],
       error: ProtocolError.InvalidQuorumCertificate[A]
   ) extends SyncEvent[A]
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -2,6 +2,7 @@ package io.iohk.metronome.hotstuff.service.tracing
 
 import io.iohk.metronome.hotstuff.consensus.basic.Agreement
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
+import io.iohk.metronome.hotstuff.service.Status
 
 sealed trait SyncEvent[+A <: Agreement]
 
@@ -25,6 +26,13 @@ object SyncEvent {
       sender: A#PKey,
       response: SyncMessage[A] with SyncMessage.Response,
       maybeError: Option[Throwable]
+  ) extends SyncEvent[A]
+
+  /** Performed a poll for `Status` across the federation. Federation members that
+    * didn't respond in time are represented by `None` in the results.
+    */
+  case class StatusPoll[A <: Agreement](
+      statuses: Map[A#PKey, Option[Status[A]]]
   ) extends SyncEvent[A]
 
   /** An unexpected error in one of the background tasks. */

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
@@ -29,7 +29,7 @@ object SyncTracers {
     (IndexedSeq[A#PKey], IndexedSeq[Option[Validated[Status[A]]]])
 
   type StatusError[A <: Agreement] =
-    (Status[A], ProtocolError.InvalidQuorumCertificate[A])
+    (Status[A], ProtocolError.InvalidQuorumCertificate[A], String)
 
   def apply[F[_], A <: Agreement](
       tracer: Tracer[F, SyncEvent[A]]
@@ -48,9 +48,10 @@ object SyncTracers {
             }
           }
         },
-      invalidStatus = tracer.contramap[StatusError[A]] { case (status, error) =>
-        InvalidStatus(status, error)
-      },
+      invalidStatus =
+        tracer.contramap[StatusError[A]] { case (status, error, hint) =>
+          InvalidStatus(status, error, hint)
+        },
       error = tracer.contramap[Throwable](Error(_))
     )
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
@@ -1,6 +1,7 @@
 package io.iohk.metronome.hotstuff.service.tracing
 
 import cats.implicits._
+import io.iohk.metronome.core.Validated
 import io.iohk.metronome.tracer.Tracer
 import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, ProtocolError}
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
@@ -11,7 +12,7 @@ case class SyncTracers[F[_], A <: Agreement](
     requestTimeout: Tracer[F, SyncTracers.Request[A]],
     responseIgnored: Tracer[F, SyncTracers.Response[A]],
     statusPoll: Tracer[F, SyncTracers.Statuses[A]],
-    invalidQC: Tracer[F, ProtocolError.InvalidQuorumCertificate[A]],
+    invalidStatus: Tracer[F, SyncTracers.StatusError[A]],
     error: Tracer[F, Throwable]
 )
 
@@ -25,7 +26,10 @@ object SyncTracers {
     (A#PKey, SyncMessage[A] with SyncMessage.Response, Option[Throwable])
 
   type Statuses[A <: Agreement] =
-    (IndexedSeq[A#PKey], IndexedSeq[Option[Status[A]]])
+    (IndexedSeq[A#PKey], IndexedSeq[Option[Validated[Status[A]]]])
+
+  type StatusError[A <: Agreement] =
+    (Status[A], ProtocolError.InvalidQuorumCertificate[A])
 
   def apply[F[_], A <: Agreement](
       tracer: Tracer[F, SyncEvent[A]]
@@ -44,10 +48,9 @@ object SyncTracers {
             }
           }
         },
-      invalidQC = tracer
-        .contramap[ProtocolError.InvalidQuorumCertificate[A]](
-          InvalidStatusQuorumCertificate(_)
-        ),
+      invalidStatus = tracer.contramap[StatusError[A]] { case (status, error) =>
+        InvalidStatus(status, error)
+      },
       error = tracer.contramap[Throwable](Error(_))
     )
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncTracers.scala
@@ -4,11 +4,13 @@ import cats.implicits._
 import io.iohk.metronome.tracer.Tracer
 import io.iohk.metronome.hotstuff.consensus.basic.Agreement
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
+import io.iohk.metronome.hotstuff.service.Status
 
 case class SyncTracers[F[_], A <: Agreement](
     queueFull: Tracer[F, A#PKey],
     requestTimeout: Tracer[F, SyncTracers.Request[A]],
     responseIgnored: Tracer[F, SyncTracers.Response[A]],
+    statusPoll: Tracer[F, SyncTracers.Statuses[A]],
     error: Tracer[F, Throwable]
 )
 
@@ -21,6 +23,9 @@ object SyncTracers {
   type Response[A <: Agreement] =
     (A#PKey, SyncMessage[A] with SyncMessage.Response, Option[Throwable])
 
+  type Statuses[A <: Agreement] =
+    (IndexedSeq[A#PKey], IndexedSeq[Option[Status[A]]])
+
   def apply[F[_], A <: Agreement](
       tracer: Tracer[F, SyncEvent[A]]
   ): SyncTracers[F, A] =
@@ -30,6 +35,10 @@ object SyncTracers {
         .contramap[Request[A]]((RequestTimeout.apply[A] _).tupled),
       responseIgnored = tracer
         .contramap[Response[A]]((ResponseIgnored.apply[A] _).tupled),
+      statusPoll = tracer
+        .contramap[Statuses[A]] { case (publicKeys, maybeStatuses) =>
+          StatusPoll[A]((publicKeys zip maybeStatuses).toMap)
+        },
       error = tracer.contramap[Throwable](Error(_))
     )
 }

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -329,9 +329,9 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
     for {
       m   <- arbitrary[Int].map(_.toLong)
       l   <- Gen.posNum[Int]
-      h   <- Gen.oneOf(l, l + 1)
+      h   <- Gen.oneOf(l, l - 1)
       ls  <- Gen.listOfN(l, Gen.posNum[Int].map(m - _))
-      hs  <- Gen.listOfN(l, Gen.posNum[Int].map(m + _))
+      hs  <- Gen.listOfN(h, Gen.posNum[Int].map(m + _))
       rnd <- arbitrary[Int].map(new Random(_))
     } yield (m, rnd.shuffle(ls ++ Seq(m) ++ hs))
   ) { case (m, xs) =>

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -1,0 +1,307 @@
+package io.iohk.metronome.hotstuff.service.sync
+
+import cats.effect.concurrent.Ref
+import io.iohk.metronome.hotstuff.consensus.{
+  Federation,
+  LeaderSelection,
+  ViewNumber
+}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  ProtocolStateCommands,
+  QuorumCertificate,
+  Phase,
+  Signing
+}
+import io.iohk.metronome.hotstuff.service.Status
+import io.iohk.metronome.hotstuff.service.tracing.{SyncTracers, SyncEvent}
+import io.iohk.metronome.tracer.Tracer
+import monix.eval.Task
+import monix.execution.schedulers.TestScheduler
+import org.scalacheck.{Arbitrary, Properties, Gen}
+import org.scalacheck.Prop.{forAll, propBoolean, all}
+import scala.concurrent.duration._
+import java.util.concurrent.TimeoutException
+
+object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
+  import ProtocolStateCommands.{
+    TestAgreement,
+    mockSigning,
+    mockSigningKey,
+    genInitialState,
+    genHash
+  }
+
+  /** Projected responses in each round from every federation member. */
+  type Responses = Vector[Map[TestAgreement.PKey, TestResponse]]
+
+  case class TestFixture(
+      rounds: Int,
+      federation: Federation[TestAgreement.PKey],
+      responses: Responses
+  ) {
+    val responseCounterRef =
+      Ref.unsafe[Task, Map[TestAgreement.PKey, Int]](
+        federation.publicKeys.map(_ -> 0).toMap
+      )
+
+    val syncEventsRef =
+      Ref.unsafe[Task, Vector[SyncEvent[TestAgreement]]](Vector.empty)
+
+    private val syncEventTracer =
+      Tracer.instance[Task, SyncEvent[TestAgreement]] { event =>
+        syncEventsRef.update(_ :+ event)
+      }
+
+    implicit val syncTracers: SyncTracers[Task, TestAgreement] =
+      SyncTracers(syncEventTracer)
+
+    def getStatus(
+        publicKey: TestAgreement.PKey
+    ): Task[Option[Status[TestAgreement]]] =
+      for {
+        round <- responseCounterRef.modify { responseCounter =>
+          val count = responseCounter(publicKey)
+          responseCounter.updated(publicKey, count + 1) -> count
+        }
+        result =
+          if (round >= responses.size) None
+          else
+            responses(round)(publicKey) match {
+              case TestResponse.Timeout               => None
+              case TestResponse.InvalidStatus(status) => Some(status)
+              case TestResponse.ValidStatus(status)   => Some(status)
+            }
+      } yield result
+  }
+
+  object TestFixture {
+    implicit val leaderSelection = LeaderSelection.RoundRobin
+
+    implicit val arb: Arbitrary[TestFixture] = Arbitrary {
+      for {
+        state <- genInitialState
+        federation = Federation(state.federation, state.f).getOrElse(
+          sys.error("Invalid federation.")
+        )
+        byzantineCount <- Gen.choose(0, state.f)
+        byzantines = federation.publicKeys.take(byzantineCount).toSet
+        rounds <- Gen.posNum[Int]
+        genesisQC = state.newViewsHighQC
+        responses <- genResponses(rounds, federation, byzantines, genesisQC)
+      } yield TestFixture(
+        rounds,
+        federation,
+        responses
+      )
+    }
+  }
+
+  sealed trait TestResponse
+  object TestResponse {
+    case object Timeout                                     extends TestResponse
+    case class ValidStatus(status: Status[TestAgreement])   extends TestResponse
+    case class InvalidStatus(status: Status[TestAgreement]) extends TestResponse
+  }
+
+  /** Generate a series of hypothetical responses projected from an idealized consensus process. */
+  def genResponses(
+      rounds: Int,
+      federation: Federation[TestAgreement.PKey],
+      byzantines: Set[TestAgreement.PKey],
+      genesisQC: QuorumCertificate[TestAgreement]
+  ): Gen[Responses] = {
+
+    def genPrepareQC(qc: QuorumCertificate[TestAgreement]) =
+      for {
+        quorumKeys <- Gen
+          .pick(federation.quorumSize, federation.publicKeys)
+          .map(_.toVector)
+        blockHash <- genHash
+        viewNumber = qc.viewNumber.next
+        partialSigs = quorumKeys.map { publicKey =>
+          val signingKey = mockSigningKey(publicKey)
+          Signing[TestAgreement].sign(
+            signingKey,
+            Phase.Prepare,
+            viewNumber,
+            blockHash
+          )
+        }
+        groupSig = mockSigning.combine(partialSigs)
+      } yield QuorumCertificate[TestAgreement](
+        Phase.Prepare,
+        viewNumber,
+        blockHash,
+        groupSig
+      )
+
+    def genCommitQC(qc: QuorumCertificate[TestAgreement]) =
+      for {
+        quorumKeys <- Gen
+          .pick(federation.quorumSize, federation.publicKeys)
+          .map(_.toVector)
+        blockHash  = qc.blockHash
+        viewNumber = qc.viewNumber
+        partialSigs = quorumKeys.map { publicKey =>
+          val signingKey = mockSigningKey(publicKey)
+          Signing[TestAgreement].sign(
+            signingKey,
+            Phase.Commit,
+            viewNumber,
+            blockHash
+          )
+        }
+        groupSig = mockSigning.combine(partialSigs)
+      } yield QuorumCertificate[TestAgreement](
+        Phase.Commit,
+        viewNumber,
+        blockHash,
+        groupSig
+      )
+
+    def genInvalid(status: Status[TestAgreement]) = {
+      def delay(invalid: => Status[TestAgreement]) =
+        Gen.delay(Gen.const(invalid))
+      Gen.oneOf(
+        delay(status.copy(viewNumber = status.prepareQC.viewNumber.prev)),
+        delay(status.copy(prepareQC = status.commitQC)),
+        delay(status.copy(commitQC = status.prepareQC)),
+        delay(
+          status.copy(commitQC =
+            status.commitQC.copy[TestAgreement](signature =
+              status.commitQC.signature
+                .copy(sig = status.commitQC.signature.sig.map(_ + 1))
+            )
+          )
+        ).filter(_.commitQC.viewNumber > 0)
+      )
+    }
+
+    def loop(
+        round: Int,
+        prepareQC: QuorumCertificate[TestAgreement],
+        commitQC: QuorumCertificate[TestAgreement],
+        accum: Responses
+    ): Gen[Responses] =
+      if (round == rounds) Gen.const(accum)
+      else {
+        val genRound = for {
+          nextPrepareQC <- Gen.oneOf(
+            Gen.const(prepareQC),
+            genPrepareQC(prepareQC)
+          )
+          nextCommitQC <- Gen.oneOf(
+            Gen.const(commitQC),
+            genCommitQC(prepareQC).filter(_.viewNumber > 0),
+            genCommitQC(nextPrepareQC).filter(_.viewNumber > 0)
+          )
+          status = Status(ViewNumber(round + 1), nextPrepareQC, nextCommitQC)
+          responses <- Gen.sequence[Vector[TestResponse], TestResponse] {
+            federation.publicKeys.map { publicKey =>
+              if (byzantines.contains(publicKey)) {
+                Gen.frequency(
+                  3 -> Gen.const(TestResponse.Timeout),
+                  2 -> Gen.const(TestResponse.ValidStatus(status)),
+                  5 -> genInvalid(status).map(TestResponse.InvalidStatus(_))
+                )
+              } else {
+                Gen.frequency(
+                  1 -> TestResponse.Timeout,
+                  4 -> TestResponse.ValidStatus(status)
+                )
+              }
+            }
+          }
+          responseMap = (federation.publicKeys zip responses).toMap
+        } yield (nextPrepareQC, nextCommitQC, responseMap)
+
+        genRound.flatMap { case (prepareQC, commitQC, responseMap) =>
+          loop(round + 1, prepareQC, commitQC, accum :+ responseMap)
+        }
+      }
+
+    loop(
+      0,
+      genesisQC,
+      genesisQC.copy[TestAgreement](phase = Phase.Commit),
+      Vector.empty
+    )
+  }
+
+  property("sync") = forAll { (fixture: TestFixture) =>
+    implicit val scheduler = TestScheduler()
+    import fixture.syncTracers
+
+    val retryTimeout = 5.seconds
+    val syncTimeout  = fixture.rounds * retryTimeout * 2
+    val synchronizer = new ViewSynchronizer[Task, TestAgreement](
+      federation = fixture.federation,
+      getStatus = fixture.getStatus,
+      retryTimeout = retryTimeout
+    )
+
+    val test = for {
+      status <- synchronizer.sync.timeout(syncTimeout).attempt
+      events <- fixture.syncEventsRef.get
+
+      quorumSize = fixture.federation.quorumSize
+
+      indexOfQuorum = fixture.responses.indexWhere { responseMap =>
+        responseMap.values.collect { case TestResponse.ValidStatus(_) =>
+        }.size >= quorumSize
+      }
+      hasQuorum = indexOfQuorum >= 0
+
+      invalidResponseCount = {
+        val responses =
+          if (hasQuorum) fixture.responses.take(indexOfQuorum + 1)
+          else fixture.responses
+        responses
+          .flatMap(_.values)
+          .collect { case TestResponse.InvalidStatus(_) =>
+          }
+          .size
+      }
+
+      invalidEventCount = {
+        events.collect { case x: SyncEvent.InvalidStatus[_] =>
+        }.size
+      }
+
+      pollSizes = events.collect { case SyncEvent.StatusPoll(statuses) =>
+        statuses.size
+      }
+    } yield {
+      status match {
+        case Right(status) =>
+          "status" |: all(
+            "quorum" |: hasQuorum,
+            "reports polls each round" |:
+              pollSizes.size == indexOfQuorum + 1,
+            "stop at the first quorum" |:
+              pollSizes.last >= quorumSize &&
+              pollSizes.init.forall(_ < quorumSize),
+            "reports all invalid" |:
+              invalidEventCount == invalidResponseCount
+          )
+
+        case Left(ex: TimeoutException) =>
+          "timeout" |: all(
+            "no quorum" |: !hasQuorum,
+            "empty polls" |: pollSizes.forall(_ < quorumSize),
+            "keeps polling" |: pollSizes.size >= fixture.rounds,
+            "reports all invalid" |: invalidEventCount == invalidResponseCount
+          )
+
+        case Left(ex) =>
+          ex.getMessage |: false
+      }
+    }
+
+    val testFuture = test.runToFuture
+
+    scheduler.tick(syncTimeout)
+
+    testFuture.value.get.get
+  }
+}

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -313,7 +313,8 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
 
       all(
         statusProps,
-        "poll everyone in each round" |: responseCounter.values.toList.distinct.size == 1
+        "poll everyone in each round" |:
+          responseCounter.values.toList.distinct.size <= 2 // Some members can get an extra query, down to timing.
       )
     }
 


### PR DESCRIPTION
Added a ViewSynchronizer component that asks all federation members for their current Status and determines the best values to adopt: it picks the highest Prepare and Commit Quorum Certificates, and the median View Number. The former have signatures to prove their validity, but the latter could be gamed by adversarial actors, hence not using the highest value. Multiple rounds of peers trying to sync with each other and picking the median should make them converge in the end.

The integration with the services is in https://github.com/input-output-hk/metronome/pull/37