### PR TITLE
PM-2941: Config parser

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -219,7 +219,11 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       ivy"io.circe::circe-parser:${VersionOf.circe}"
     )
 
-    object test extends TestModule
+    object test extends TestModule {
+      override def ivyDeps = super.ivyDeps() ++ Agg(
+        ivy"io.circe::circe-generic:${VersionOf.circe}"
+      )
+    }
   }
 
   /** Generic HotStuff BFT library. */

--- a/build.sc
+++ b/build.sc
@@ -211,6 +211,17 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
     }
   }
 
+  /** General configuration parser, to be used by application modules. */
+  object config extends SubModule {
+    override def ivyDeps = super.ivyDeps() ++ Agg(
+      ivy"com.typesafe:config:${VersionOf.config}",
+      ivy"io.circe::circe-core:${VersionOf.circe}",
+      ivy"io.circe::circe-parser:${VersionOf.circe}"
+    )
+
+    object test extends TestModule
+  }
+
   /** Generic HotStuff BFT library. */
   object hotstuff extends SubModule {
 
@@ -310,10 +321,16 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       */
     object app extends SubModule {
       override def moduleDeps: Seq[JavaModule] =
-        Seq(hotstuff.service, checkpointing.service, rocksdb, logging, metrics)
+        Seq(
+          hotstuff.service,
+          checkpointing.service,
+          rocksdb,
+          logging,
+          metrics,
+          config
+        )
 
       override def ivyDeps = super.ivyDeps() ++ Agg(
-        ivy"com.typesafe:config:${VersionOf.config}",
         ivy"ch.qos.logback:logback-classic:${VersionOf.logback}",
         ivy"io.iohk::scalanet-discovery:${VersionOf.scalanet}",
         ivy"io.monix::monix:${VersionOf.monix}"

--- a/metronome/config/src/io/iohk/metronome/config/ConfigDecoders.scala
+++ b/metronome/config/src/io/iohk/metronome/config/ConfigDecoders.scala
@@ -1,0 +1,29 @@
+package io.iohk.metronome.config
+
+import io.circe._
+import com.typesafe.config.{ConfigFactory, Config}
+import scala.util.Try
+import scala.concurrent.duration._
+
+object ConfigDecoders {
+
+  /** Parse a string into a TypeSafe config an use one of the accessor methods. */
+  private def tryParse[T](value: String, f: (Config, String) => T): Try[T] =
+    Try {
+      val key  = "dummy"
+      val conf = ConfigFactory.parseString(s"$key = $value")
+      f(conf, key)
+    }
+
+  /** Parse HOCON byte sizes like "128M". */
+  val bytesDecoder: Decoder[Long] =
+    Decoder[String].emapTry {
+      tryParse(_, _ getBytes _)
+    }
+
+  /** Parse HOCON durations like "5m". */
+  val durationDecoder: Decoder[FiniteDuration] =
+    Decoder[String].emapTry {
+      tryParse(_, _.getDuration(_).toMillis.millis)
+    }
+}

--- a/metronome/config/src/io/iohk/metronome/config/ConfigDecoders.scala
+++ b/metronome/config/src/io/iohk/metronome/config/ConfigDecoders.scala
@@ -26,4 +26,53 @@ object ConfigDecoders {
     Decoder[String].emapTry {
       tryParse(_, _.getDuration(_).toMillis.millis)
     }
+
+  /** Parse an object where a discriminant tells us which other key value
+    * to deserialise into the target type.
+    *
+    * For example take the following config:
+    *
+    * ```
+    * virus {
+    *   variant = alpha
+    *   alpha {
+    *     r = 1.1
+    *   }
+    *   delta {
+    *     r = 1.4
+    *   }
+    * }
+    *
+    * It should deserialize into a class that matches a sub-key:
+    * ```
+    * case class Virus(r: Double)
+    * object Virus {
+    *   implicit val decoder: Decoder[Virus] =
+    *     ConfigDecoders.strategyDecoder[Virus]("variant", deriveDecoder)
+    * }
+    * ```
+    *
+    * The decoder will deserialise all the other keys as well to make sure
+    * that all of them are valid, in case the selection changes.
+    */
+  def strategyDecoder[T](
+      discriminant: String,
+      decoder: Decoder[T]
+  ): Decoder[T] = {
+    // Not passing the decoder implicitly so the compiler doesn't pass
+    // the one we are constructing here.
+    implicit val inner: Decoder[T] = decoder
+
+    Decoder.instance[T] { (c: HCursor) =>
+      for {
+        obj      <- c.value.as[JsonObject]
+        selected <- c.downField(discriminant).as[String]
+        value    <- c.downField(selected).as[T]
+        // Making sure that everything else is valid. We could pick the value from the result,
+        // but it's more difficult to provide the right `DecodingFailure` with a list of operations
+        // if the selected key is not present in the map.
+        _ <- Json.fromJsonObject(obj.remove(discriminant)).as[Map[String, T]]
+      } yield value
+    }
+  }
 }

--- a/metronome/config/src/io/iohk/metronome/config/ConfigParser.scala
+++ b/metronome/config/src/io/iohk/metronome/config/ConfigParser.scala
@@ -1,10 +1,12 @@
 package io.iohk.metronome.config
 
+import cats.implicits._
+import com.typesafe.config.{ConfigObject, ConfigRenderOptions}
 import io.circe.{Json, JsonObject, ParsingFailure}
 import io.circe.parser.parse
-import com.typesafe.config.{ConfigObject, ConfigRenderOptions}
 
 object ConfigParser {
+  type ParsingResult = Either[ParsingFailure, Json]
 
   /** Render a TypeSafe Config section into JSON. */
   def toJson(conf: ConfigObject): Json = {
@@ -19,21 +21,6 @@ object ConfigParser {
       case Right(json) =>
         json
     }
-  }
-
-  /** Transform all keys into camelCase form,
-    * so they can be matched to case class fields.
-    */
-  def toCamelCase(json: Json): Json = {
-    json
-      .mapArray { arr =>
-        arr.map(toCamelCase)
-      }
-      .mapObject { obj =>
-        JsonObject(obj.toIterable.map { case (key, value) =>
-          toCamelCase(key) -> toCamelCase(value)
-        }.toList: _*)
-      }
   }
 
   /** Transform a key in the HOCON config file to camelCase. */
@@ -51,13 +38,106 @@ object ConfigParser {
     loop(key.toList, Nil)
   }
 
-  /** Apply overrides from the environment to a JSON structure. */
-  // def withEnvVarOverrides(json: Json, prefix: String): Json = {
-  //   def loop(json: Json, path: ): Json =
-  // }
-
-  /** Turn `camelCaseKey` into `CAMEL_CASE_KEY`,
+  /** Turn `camelCaseKey` into `SNAKE_CASE_KEY`,
     * which is what it would look like as an env var.
     */
-  // def snakeify(camelCase: String): String = ???
+  def toSnakeCase(camelCase: String): String = {
+    def loop(cs: List[Char], acc: List[Char]): String =
+      cs match {
+        case a :: b :: cs if a.isLower && b.isUpper =>
+          loop(cs, b :: '_' :: a.toUpper :: acc)
+        case '-' :: cs =>
+          loop(cs, '_' :: acc)
+        case a :: cs =>
+          loop(cs, a.toUpper :: acc)
+        case Nil =>
+          acc.reverse.mkString
+      }
+    loop(camelCase.toList, Nil)
+  }
+
+  /** Transform all keys into camelCase form,
+    * so they can be matched to case class fields.
+    */
+  def withCamelCase(json: Json): Json = {
+    json
+      .mapArray { arr =>
+        arr.map(withCamelCase)
+      }
+      .mapObject { obj =>
+        JsonObject(obj.toIterable.map { case (key, value) =>
+          toCamelCase(key) -> withCamelCase(value)
+        }.toList: _*)
+      }
+  }
+
+  /** Apply overrides from the environment to a JSON structure.
+    *
+    * Only considers env var keys that start with prefix and are
+    * in a PREFIX_SNAKE_CASE format.
+    */
+  def withEnvVarOverrides(
+      json: Json,
+      prefix: String,
+      env: Map[String, String] = sys.env
+  ): ParsingResult = {
+    def extend(path: String, key: String) =
+      if (path.isEmpty) key else s"${path}_${key}"
+
+    def loop(json: Json, path: String): ParsingResult = {
+
+      def tryParse(
+          default: => Json,
+          validate: Json => Boolean
+      ): ParsingResult =
+        env
+          .get(path)
+          .map { value =>
+            val maybeJson = parse(value) orElse parse(s""""$value"""")
+
+            maybeJson.flatMap { json =>
+              if (validate(json)) {
+                Right(json)
+              } else {
+                val msg = s"Invalid value for $path: $value"
+                Left(ParsingFailure(value, new IllegalArgumentException(msg)))
+              }
+            }
+          }
+          .getOrElse(Right(default))
+
+      json
+        .fold[ParsingResult](
+          jsonNull = tryParse(Json.Null, _ => true),
+          jsonBoolean = x => tryParse(Json.fromBoolean(x), _.isBoolean),
+          jsonNumber = x => tryParse(Json.fromJsonNumber(x), _.isNumber),
+          jsonString = x => tryParse(Json.fromString(x), _.isString),
+          jsonArray = { arr =>
+            arr.zipWithIndex
+              .map { case (value, idx) =>
+                loop(value, extend(path, idx.toString))
+              }
+              .sequence
+              .map { values =>
+                Json.arr(values: _*)
+              }
+          },
+          jsonObject = { obj =>
+            obj.toIterable
+              .map { case (key, value) =>
+                val snakeKey = toSnakeCase(key)
+                loop(value, extend(path, snakeKey)).map(key ->)
+              }
+              .toList
+              .sequence
+              .map { values =>
+                Json.obj(values: _*)
+              }
+          }
+        )
+    }
+
+    loop(json, prefix)
+  }
+
 }

--- a/metronome/config/src/io/iohk/metronome/config/ConfigParser.scala
+++ b/metronome/config/src/io/iohk/metronome/config/ConfigParser.scala
@@ -48,35 +48,37 @@ object ConfigParser {
 
   /** Transform a key in the HOCON config file to camelCase. */
   protected[config] def toCamelCase(key: String): String = {
-    def loop(cs: List[Char], acc: List[Char]): String =
+    def loop(cs: List[Char]): List[Char] =
       cs match {
         case ('_' | '-') :: cs =>
           cs match {
-            case c :: cs => loop(cs, c.toUpper :: acc)
-            case cs      => loop(cs, acc)
+            case c :: cs => c.toUpper :: loop(cs)
+            case cs      => loop(cs)
           }
-        case c :: cs => loop(cs, c :: acc)
-        case Nil     => acc.reverse.mkString
+        case c :: cs => c :: loop(cs)
+        case Nil     => Nil
       }
-    loop(key.toList, Nil)
+
+    loop(key.toList).mkString
   }
 
   /** Turn `camelCaseKey` into `SNAKE_CASE_KEY`,
     * which is what it would look like as an env var.
     */
   protected[config] def toSnakeCase(camelCase: String): String = {
-    def loop(cs: List[Char], acc: List[Char]): String =
+    def loop(cs: List[Char]): List[Char] =
       cs match {
         case a :: b :: cs if a.isLower && b.isUpper =>
-          loop(cs, b :: '_' :: a.toUpper :: acc)
+          a.toUpper :: '_' :: b :: loop(cs)
         case '-' :: cs =>
-          loop(cs, '_' :: acc)
+          '_' :: loop(cs)
         case a :: cs =>
-          loop(cs, a.toUpper :: acc)
+          a.toUpper :: loop(cs)
         case Nil =>
-          acc.reverse.mkString
+          Nil
       }
-    loop(camelCase.toList, Nil)
+
+    loop(camelCase.toList).mkString
   }
 
   /** Transform all keys into camelCase form,

--- a/metronome/config/src/io/iohk/metronome/config/ConfigParser.scala
+++ b/metronome/config/src/io/iohk/metronome/config/ConfigParser.scala
@@ -53,7 +53,7 @@ object ConfigParser {
         case ('_' | '-') :: cs =>
           cs match {
             case c :: cs => c.toUpper :: loop(cs)
-            case cs      => loop(cs)
+            case Nil     => Nil
           }
         case c :: cs => c :: loop(cs)
         case Nil     => Nil

--- a/metronome/config/src/io/iohk/metronome/config/ConfigParser.scala
+++ b/metronome/config/src/io/iohk/metronome/config/ConfigParser.scala
@@ -1,0 +1,63 @@
+package io.iohk.metronome.config
+
+import io.circe.{Json, JsonObject, ParsingFailure}
+import io.circe.parser.parse
+import com.typesafe.config.{ConfigObject, ConfigRenderOptions}
+
+object ConfigParser {
+
+  /** Render a TypeSafe Config section into JSON. */
+  def toJson(conf: ConfigObject): Json = {
+    val raw = conf.render(ConfigRenderOptions.concise)
+    parse(raw) match {
+      case Left(error: ParsingFailure) =>
+        // This shouldn't happen with a well formed config file,
+        // which would have already failed during parsing or projecting
+        // to a `ConfigObject` passed to this method.
+        throw new IllegalArgumentException(error.message, error.underlying)
+
+      case Right(json) =>
+        json
+    }
+  }
+
+  /** Transform all keys into camelCase form,
+    * so they can be matched to case class fields.
+    */
+  def toCamelCase(json: Json): Json = {
+    json
+      .mapArray { arr =>
+        arr.map(toCamelCase)
+      }
+      .mapObject { obj =>
+        JsonObject(obj.toIterable.map { case (key, value) =>
+          toCamelCase(key) -> toCamelCase(value)
+        }.toList: _*)
+      }
+  }
+
+  /** Transform a key in the HOCON config file to camelCase. */
+  def toCamelCase(key: String): String = {
+    def loop(cs: List[Char], acc: List[Char]): String =
+      cs match {
+        case ('_' | '-') :: cs =>
+          cs match {
+            case c :: cs => loop(cs, c.toUpper :: acc)
+            case cs      => loop(cs, acc)
+          }
+        case c :: cs => loop(cs, c :: acc)
+        case Nil     => acc.reverse.mkString
+      }
+    loop(key.toList, Nil)
+  }
+
+  /** Apply overrides from the environment to a JSON structure. */
+  // def withEnvVarOverrides(json: Json, prefix: String): Json = {
+  //   def loop(json: Json, path: ): Json =
+  // }
+
+  /** Turn `camelCaseKey` into `CAMEL_CASE_KEY`,
+    * which is what it would look like as an env var.
+    */
+  // def snakeify(camelCase: String): String = ???
+}

--- a/metronome/config/test/resources/complex.conf
+++ b/metronome/config/test/resources/complex.conf
@@ -1,0 +1,13 @@
+metronome {
+  metrics {
+    enabled = false
+  }
+  network {
+    bootstrap = [
+      "localhost:40001"
+    ],
+    timeout = 5s
+    max-packet-size = 512kB
+  }
+  client-id = null
+}

--- a/metronome/config/test/resources/complex.conf
+++ b/metronome/config/test/resources/complex.conf
@@ -8,6 +8,7 @@ metronome {
     ],
     timeout = 5s
     max-packet-size = 512kB
+    client-id = null
   }
-  client-id = null
+  chain-id = test-chain
 }

--- a/metronome/config/test/resources/complex.conf
+++ b/metronome/config/test/resources/complex.conf
@@ -10,5 +10,18 @@ metronome {
     max-packet-size = 512kB
     client-id = null
   }
+  blockchain {
+    consensus = "development"
+    default {
+      max-block-size = 1MB
+      view-timeout = 15s
+    }
+    development = ${metronome.blockchain.default} {
+      max-block-size = 10MB
+    }
+    main = ${metronome.blockchain.default} {
+      view-timeout = 5s
+    }
+  }
   chain-id = test-chain
 }

--- a/metronome/config/test/resources/override.conf
+++ b/metronome/config/test/resources/override.conf
@@ -10,10 +10,11 @@ override {
   }
   optional = null
   numeric = 123
-  textual = hello world
+  textual = Hello World
   boolean = true
 }
 
+# Other setting that shouldn't be affected.
 other {
   metrics {
     enabled = false

--- a/metronome/config/test/resources/override.conf
+++ b/metronome/config/test/resources/override.conf
@@ -1,0 +1,21 @@
+override {
+  metrics {
+    enabled = false
+  }
+  network {
+    bootstrap = [
+      "localhost:40001",
+      "localhost:40002"
+    ]
+  }
+  optional = null
+  numeric = 123
+  textual = hello world
+  boolean = true
+}
+
+other {
+  metrics {
+    enabled = false
+  }
+}

--- a/metronome/config/test/resources/simple.conf
+++ b/metronome/config/test/resources/simple.conf
@@ -1,0 +1,8 @@
+simple {
+  nested-structure {
+      foo = 10
+      bar_baz {
+        spam = eggs
+      }
+  }
+}

--- a/metronome/config/test/resources/simple.conf
+++ b/metronome/config/test/resources/simple.conf
@@ -1,6 +1,9 @@
+# The root we are going to start from.
 simple {
+  # Property name with a dash.
   nested-structure {
       foo = 10
+      # Property name with an underscore.
       bar_baz {
         spam = eggs
       }

--- a/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
+++ b/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
@@ -110,6 +110,11 @@ class ConfigParserSpec
           maxPacketSize = TestConfig.Size(512000),
           clientId = None
         ),
+        TestConfig
+          .Blockchain(
+            maxBlockSize = TestConfig.Size(10000000),
+            viewTimeout = 15.seconds
+          ),
         chainId = Some("test-chain")
       )
     }
@@ -122,9 +127,13 @@ object ConfigParserSpec {
   case class TestConfig(
       metrics: TestConfig.Metrics,
       network: TestConfig.Network,
+      blockchain: TestConfig.Blockchain,
       chainId: Option[String]
   )
   object TestConfig {
+    implicit val durationDecoder: Decoder[FiniteDuration] =
+      ConfigDecoders.durationDecoder
+
     case class Metrics(enabled: Boolean)
     object Metrics {
       implicit val decoder: Decoder[Metrics] =
@@ -138,9 +147,6 @@ object ConfigParserSpec {
         clientId: Option[String]
     )
     object Network {
-      implicit val durationDecoder: Decoder[FiniteDuration] =
-        ConfigDecoders.durationDecoder
-
       implicit val decoder: Decoder[Network] =
         deriveDecoder
     }
@@ -149,6 +155,15 @@ object ConfigParserSpec {
     object Size {
       implicit val decoder: Decoder[Size] =
         ConfigDecoders.bytesDecoder.map(Size(_))
+    }
+
+    case class Blockchain(
+        maxBlockSize: Size,
+        viewTimeout: FiniteDuration
+    )
+    object Blockchain {
+      implicit val decoder: Decoder[Blockchain] =
+        ConfigDecoders.strategyDecoder[Blockchain]("consensus", deriveDecoder)
     }
 
     implicit val decoder: Decoder[TestConfig] =

--- a/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
+++ b/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
@@ -107,9 +107,10 @@ class ConfigParserSpec
         TestConfig.Network(
           bootstrap = List("localhost:40001"),
           timeout = 5.seconds,
-          maxPacketSize = TestConfig.Size(512000)
+          maxPacketSize = TestConfig.Size(512000),
+          clientId = None
         ),
-        clientId = None
+        chainId = Some("test-chain")
       )
     }
   }
@@ -121,7 +122,7 @@ object ConfigParserSpec {
   case class TestConfig(
       metrics: TestConfig.Metrics,
       network: TestConfig.Network,
-      clientId: Option[String]
+      chainId: Option[String]
   )
   object TestConfig {
     case class Metrics(enabled: Boolean)
@@ -133,7 +134,8 @@ object ConfigParserSpec {
     case class Network(
         bootstrap: List[String],
         timeout: FiniteDuration,
-        maxPacketSize: Size
+        maxPacketSize: Size,
+        clientId: Option[String]
     )
     object Network {
       implicit val durationDecoder: Decoder[FiniteDuration] =

--- a/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
+++ b/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
@@ -1,0 +1,38 @@
+package io.iohk.metronome.config
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class ConfigParserSpec
+    extends AnyFlatSpec
+    with Matchers
+    with TableDrivenPropertyChecks {
+  "toJson" should "parse simple.conf to JSON" in {
+    val conf = ConfigFactory.load("simple.conf")
+    val json = ConfigParser.toJson(conf.getConfig("simple").root())
+    json.noSpaces shouldBe """{"nested-structure":{"bar_baz":{"spam":"eggs"},"foo":10}}"""
+  }
+
+  "toCamelCase" should "turn keys into camel case" in {
+    val examples = Table(
+      ("input", "expected"),
+      ("nested-structure", "nestedStructure"),
+      ("nested_structure", "nestedStructure"),
+      ("multiple-dashes_and_underscores", "multipleDashesAndUnderscores"),
+      ("multiple-dashes_and_underscores", "multipleDashesAndUnderscores"),
+      ("camelCasedKeys", "camelCasedKeys")
+    )
+    forAll(examples) { case (input, expected) =>
+      ConfigParser.toCamelCase(input) shouldBe expected
+    }
+  }
+
+  it should "turn all keys in a JSON object into camel case" in {
+    val conf = ConfigFactory.load("simple.conf")
+    val orig = ConfigParser.toJson(conf.root())
+    val json = (ConfigParser.toCamelCase(orig) \\ "simple").head
+    json.noSpaces shouldBe """{"nestedStructure":{"barBaz":{"spam":"eggs"},"foo":10}}"""
+  }
+}

--- a/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
+++ b/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
@@ -101,7 +101,7 @@ class ConfigParserSpec
       env = Map("TEST_METRICS_ENABLED" -> "true")
     )
 
-    inside(config) { case Right(Right(config)) =>
+    inside(config) { case Right(config) =>
       config shouldBe TestConfig(
         TestConfig.Metrics(enabled = true),
         TestConfig.Network(

--- a/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
+++ b/metronome/config/test/src/io/iohk/metronome/config/ConfigParserSpec.scala
@@ -4,35 +4,89 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.Inside
 
 class ConfigParserSpec
     extends AnyFlatSpec
     with Matchers
-    with TableDrivenPropertyChecks {
+    with TableDrivenPropertyChecks
+    with Inside {
   "toJson" should "parse simple.conf to JSON" in {
     val conf = ConfigFactory.load("simple.conf")
     val json = ConfigParser.toJson(conf.getConfig("simple").root())
     json.noSpaces shouldBe """{"nested-structure":{"bar_baz":{"spam":"eggs"},"foo":10}}"""
   }
 
-  "toCamelCase" should "turn keys into camel case" in {
+  "toCamelCase" should "turn keys into camelCase" in {
     val examples = Table(
       ("input", "expected"),
       ("nested-structure", "nestedStructure"),
       ("nested_structure", "nestedStructure"),
       ("multiple-dashes_and_underscores", "multipleDashesAndUnderscores"),
       ("multiple-dashes_and_underscores", "multipleDashesAndUnderscores"),
-      ("camelCasedKeys", "camelCasedKeys")
+      ("camelCaseKey", "camelCaseKey")
     )
     forAll(examples) { case (input, expected) =>
       ConfigParser.toCamelCase(input) shouldBe expected
     }
   }
 
-  it should "turn all keys in a JSON object into camel case" in {
+  "toSnakeCase" should "turn camelCase keys into SNAKE_CASE" in {
+    val examples = Table(
+      ("input", "expected"),
+      ("nestedStructure", "NESTED_STRUCTURE"),
+      ("nested_structure", "NESTED_STRUCTURE"),
+      ("nested-structure", "NESTED_STRUCTURE")
+    )
+    forAll(examples) { case (input, expected) =>
+      ConfigParser.toSnakeCase(input) shouldBe expected
+    }
+  }
+
+  "withCamelCase" should "turn all keys in a JSON object into camelCase" in {
     val conf = ConfigFactory.load("simple.conf")
     val orig = ConfigParser.toJson(conf.root())
-    val json = (ConfigParser.toCamelCase(orig) \\ "simple").head
+    val json = (ConfigParser.withCamelCase(orig) \\ "simple").head
     json.noSpaces shouldBe """{"nestedStructure":{"barBaz":{"spam":"eggs"},"foo":10}}"""
   }
+
+  "withEnvVarOverrides" should "overwrite keys from the environment" in {
+    val conf = ConfigFactory.load("override.conf")
+    val orig = ConfigParser.toJson(conf.getConfig("override").root())
+    val json = ConfigParser.withCamelCase(orig)
+
+    val env = Map(
+      "TEST_METRICS_ENABLED"     -> "true",
+      "TEST_NETWORK_BOOTSTRAP_0" -> "localhost:50000",
+      "TEST_OPTIONAL"            -> "test",
+      "TEST_NUMERIC"             -> "456",
+      "TEST_TEXTUAL"             -> "Terra Nostra",
+      "TEST_BOOLEAN"             -> "false"
+    )
+
+    val result = ConfigParser.withEnvVarOverrides(json, "TEST", env)
+
+    inside(result) { case Right(json) =>
+      json.noSpaces shouldBe """{"boolean":false,"metrics":{"enabled":true},"network":{"bootstrap":["localhost:50000","localhost:40002"]},"numeric":456,"optional":"test","textual":"Terra Nostra"}"""
+    }
+  }
+
+  it should "validate that data types are not altered" in {
+    val conf = ConfigFactory.load("override.conf")
+    val orig = ConfigParser.toJson(conf.root())
+    val json = ConfigParser.withCamelCase(orig)
+
+    val examples = Table(
+      ("path", "invalid"),
+      ("OVERRIDE_NUMERIC", "NaN"),
+      ("OVERRIDE_TEXTUAL", "123"),
+      ("OVERRIDE_BOOLEAN", "no")
+    )
+    forAll(examples) { case (path, invalid) =>
+      ConfigParser
+        .withEnvVarOverrides(json, "", Map(path -> invalid))
+        .isLeft shouldBe true
+    }
+  }
+
 }


### PR DESCRIPTION
Created a `config` module that can be used to parse HOCON config into case classes in a single step, allowing overrides from env vars. 

One problem with how we tend to use TypeSafe config is to have a method like `MyConfig.fromConfig(root.getConfig("path.to.my.config")`, which typically returns a `MyConfig` instance, or throws an error if there's a problem with the values. The other is that we can't say when this happens, as these configuration values are sometimes accessed lazily. 

The approach here does all parsing up front, so we can get all potential problems out of the way at program startup. It may be less convenient in that it's not easy to make decisions based on the values, unless some complex parser is written. A simple case of switching between identical alternatives is encoded in the `strategyDecoder`.

The way it works is that it parses the whole config into JSON, reformats the keys to be `camelCase`, so they should match those in the case classes, then uses `circe` to decode the values. See [this test](https://github.com/input-output-hk/metronome/pull/38/files#diff-e71eb41290ac00c551bf7a3dedb73acc39025ddbb71ac8ad5fa4656f391c6b7aR95) for an example.

Overrides are supported by traversing the JSON structure and looking for keys in the environment that match the path. It also supports a prefix, to make sure we're not accidentally using an env var meant for something else. For example to override `network.performance-tracing.enabled` we would create an env var called `METRONOME_NETWORK_PERFORMANCE_TRACING_ENABLED`, assuming the prefix is `METRONOME`. NB TypeSafe config also support overrides via the [CONFIG_FORCE_](https://github.com/lightbend/config#optional-system-or-env-variable-overrides) mechanism but it's a bit more involved to match the path.