### PR TITLE
PM-3133: Block executor

### DIFF
--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
@@ -15,6 +15,9 @@ trait ApplicationService[F[_], A <: Agreement] {
   // Returns None if validation cannot be carried out due to data availability issues within a given timeout.
   def validateBlock(block: A#Block): F[Option[Boolean]]
 
+  // TODO (PM-3108, PM-3107, PM-3137, PM-3110): Tell the application to execute a block.
+  def executeBlock(block: A#Block): F[Unit]
+
   // TODO (PM-3135): Tell the application to sync any state of the block, i.e. the Ledger.
   // The `sources` are peers who most probably have this state.
   // The full `block` is given because it may not be persisted yet.

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
@@ -1,8 +1,7 @@
 package io.iohk.metronome.hotstuff.service
 
-import cats.data.NonEmptyVector
-import io.iohk.metronome.hotstuff.consensus.basic.Agreement
-import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import cats.data.{NonEmptyVector, NonEmptyList}
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
 
 /** Represents the "application" domain to the HotStuff module,
   * performing all delegations that HotStuff can't do on its own.
@@ -16,7 +15,16 @@ trait ApplicationService[F[_], A <: Agreement] {
   def validateBlock(block: A#Block): F[Option[Boolean]]
 
   // TODO (PM-3108, PM-3107, PM-3137, PM-3110): Tell the application to execute a block.
-  def executeBlock(block: A#Block): F[Unit]
+  // I cannot be sure that all blocks that get committed to gether fit into memory,
+  // so we pass them one by one, but all of them are accompanied by the final Commit Q.C.
+  // and the path of block hashes from the block being executed to the one committed.
+  // Perhaps the application service can cache the headers if it needs to produce a
+  // proof of the BFT agreement at the end.
+  def executeBlock(
+      block: A#Block,
+      commitQC: QuorumCertificate[A],
+      commitPath: NonEmptyList[A#Hash]
+  ): F[Unit]
 
   // TODO (PM-3135): Tell the application to sync any state of the block, i.e. the Ledger.
   // The `sources` are peers who most probably have this state.

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
@@ -20,11 +20,13 @@ trait ApplicationService[F[_], A <: Agreement] {
   // and the path of block hashes from the block being executed to the one committed.
   // Perhaps the application service can cache the headers if it needs to produce a
   // proof of the BFT agreement at the end.
+  // Returns a flag to indicate whether the block execution results have been persisted,
+  // whether the block and any corresponding state can be used as a starting point after a restart.
   def executeBlock(
       block: A#Block,
       commitQC: QuorumCertificate[A],
       commitPath: NonEmptyList[A#Hash]
-  ): F[Unit]
+  ): F[Boolean]
 
   // TODO (PM-3135): Tell the application to sync any state of the block, i.e. the Ledger.
   // The `sources` are peers who most probably have this state.

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
@@ -31,5 +31,7 @@ trait ApplicationService[F[_], A <: Agreement] {
   // TODO (PM-3135): Tell the application to sync any state of the block, i.e. the Ledger.
   // The `sources` are peers who most probably have this state.
   // The full `block` is given because it may not be persisted yet.
-  def syncState(sources: NonEmptyVector[A#PKey], block: A#Block): F[Unit]
+  // Return `true` if the block storage can be pruned after this operation from earlier blocks,
+  // which may not be the case if the application syncs by downloading all the blocks.
+  def syncState(sources: NonEmptyVector[A#PKey], block: A#Block): F[Boolean]
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -18,6 +18,7 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   Signing,
   QuorumCertificate
 }
+import io.iohk.metronome.hotstuff.service.execution.BlockExecutor
 import io.iohk.metronome.hotstuff.service.pipes.SyncPipe
 import io.iohk.metronome.hotstuff.service.storage.{
   BlockStorage,
@@ -30,6 +31,7 @@ import monix.catnap.ConcurrentQueue
 import scala.annotation.tailrec
 import scala.collection.immutable.Queue
 import scala.util.control.NonFatal
+import io.iohk.metronome.hotstuff.service.execution.BlockExecutor
 
 /** An effectful executor wrapping the pure HotStuff ProtocolState.
   *
@@ -43,6 +45,7 @@ class ConsensusService[
     publicKey: A#PKey,
     network: Network[F, A#PKey, Message[A]],
     appService: ApplicationService[F, A],
+    blockExecutor: BlockExecutor[F, N, A],
     blockStorage: BlockStorage[N, A],
     viewStateStorage: ViewStateStorage[N, A],
     stateRef: Ref[F, ProtocolState[A]],
@@ -50,7 +53,6 @@ class ConsensusService[
     counterRef: Ref[F, ConsensusService.MessageCounter],
     syncPipe: SyncPipe[F, A]#Left,
     eventQueue: ConcurrentQueue[F, Event[A]],
-    blockExecutionQueue: ConcurrentQueue[F, Effect.ExecuteBlocks[A]],
     fiberSet: FiberSet[F],
     maxEarlyViewNumberDiff: Int
 )(implicit tracers: ConsensusTracers[F, A], storeRunner: KVStoreRunner[F, N]) {
@@ -441,7 +443,7 @@ class ConsensusService[
         // the forground here, but it may cause the node to lose its
         // sync with the other federation members, so the execution
         // should be offloaded to another queue.
-        blockExecutionQueue.offer(effect)
+        blockExecutor.enqueue(effect)
 
       case SendMessage(recipient, message) =>
         network.sendMessage(recipient, message)
@@ -450,20 +452,6 @@ class ConsensusService[
     process.handleErrorWith { case NonFatal(ex) =>
       tracers.error(ex)
     }
-  }
-
-  /** Execute blocks in order, updating pesistent storage along the way. */
-  private def executeBlocks: F[Unit] = {
-    blockExecutionQueue.poll.flatMap { case Effect.ExecuteBlocks(_, _) =>
-      // Retrieve the blocks from the storage from the last executed
-      // to the one in the Quorum Certificate and tell the application
-      // to execute them one by one. Update the persistent view state
-      // after reach execution to remember which blocks we have truly
-      // done.
-
-      // TODO (PM-3133): Execute block
-      ???
-    } >> executeBlocks
   }
 
   private def validated(event: Event[A]): Validated[Event[A]] =
@@ -558,11 +546,19 @@ object ConsensusService {
   ): Resource[F, ConsensusService[F, N, A]] =
     for {
       fiberSet <- FiberSet[F]
+
+      blockExecutor <- BlockExecutor[F, N, A](
+        appService,
+        blockStorage,
+        viewStateStorage
+      )
+
       service <- Resource.liftF(
         build[F, N, A](
           publicKey,
           network,
           appService,
+          blockExecutor,
           blockStorage,
           viewStateStorage,
           syncPipe,
@@ -571,10 +567,11 @@ object ConsensusService {
           fiberSet
         )
       )
+
       _ <- Concurrent[F].background(service.processNetworkMessages)
       _ <- Concurrent[F].background(service.processSyncPipe)
       _ <- Concurrent[F].background(service.processEvents)
-      _ <- Concurrent[F].background(service.executeBlocks)
+
       initEffects = ProtocolState.init(initState)
       _ <- Resource.liftF(service.scheduleEffects(initEffects))
     } yield service
@@ -587,6 +584,7 @@ object ConsensusService {
       publicKey: A#PKey,
       network: Network[F, A#PKey, Message[A]],
       appService: ApplicationService[F, A],
+      blockExecutor: BlockExecutor[F, N, A],
       blockStorage: BlockStorage[N, A],
       viewStateStorage: ViewStateStorage[N, A],
       syncPipe: SyncPipe[F, A]#Left,
@@ -603,13 +601,12 @@ object ConsensusService {
       fibersRef  <- Ref[F].of(Set.empty[Fiber[F, Unit]])
       counterRef <- Ref[F].of(MessageCounter.empty)
       eventQueue <- ConcurrentQueue[F].unbounded[Event[A]](None)
-      blockExecutionQueue <- ConcurrentQueue[F]
-        .unbounded[Effect.ExecuteBlocks[A]](None)
 
       service = new ConsensusService(
         publicKey,
         network,
         appService,
+        blockExecutor,
         blockStorage,
         viewStateStorage,
         stateRef,
@@ -617,7 +614,6 @@ object ConsensusService {
         counterRef,
         syncPipe,
         eventQueue,
-        blockExecutionQueue,
         fiberSet,
         maxEarlyViewNumberDiff
       )

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -450,7 +450,7 @@ class ConsensusService[
     }
 
     process.handleErrorWith { case NonFatal(ex) =>
-      tracers.error(ex)
+      tracers.error(s"Error processing effect $effect", ex)
     }
   }
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -535,6 +535,7 @@ object ConsensusService {
       publicKey: A#PKey,
       network: Network[F, A#PKey, Message[A]],
       appService: ApplicationService[F, A],
+      blockExecutor: BlockExecutor[F, N, A],
       blockStorage: BlockStorage[N, A],
       viewStateStorage: ViewStateStorage[N, A],
       syncPipe: SyncPipe[F, A]#Left,
@@ -546,12 +547,6 @@ object ConsensusService {
   ): Resource[F, ConsensusService[F, N, A]] =
     for {
       fiberSet <- FiberSet[F]
-
-      blockExecutor <- BlockExecutor[F, N, A](
-        appService,
-        blockStorage,
-        viewStateStorage
-      )
 
       service <- Resource.liftF(
         build[F, N, A](

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
@@ -9,6 +9,7 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   Block,
   Signing
 }
+import io.iohk.metronome.hotstuff.service.execution.BlockExecutor
 import io.iohk.metronome.hotstuff.service.messages.{
   HotStuffMessage,
   SyncMessage
@@ -60,10 +61,17 @@ object HotStuffService {
 
       syncPipe <- Resource.liftF { SyncPipe[F, A] }
 
+      blockExecutor <- BlockExecutor[F, N, A](
+        appService,
+        blockStorage,
+        viewStateStorage
+      )
+
       consensusService <- ConsensusService(
         initState.publicKey,
         consensusNetwork,
         appService,
+        blockExecutor,
         blockStorage,
         viewStateStorage,
         syncPipe.left,
@@ -75,6 +83,7 @@ object HotStuffService {
         initState.federation,
         syncNetwork,
         appService,
+        blockExecutor,
         blockStorage,
         viewStateStorage,
         syncPipe.right,

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
@@ -7,13 +7,21 @@ import io.iohk.metronome.hotstuff.service.storage.{
   BlockStorage,
   ViewStateStorage
 }
-import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, Effect}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Agreement,
+  Effect,
+  QuorumCertificate
+}
+import io.iohk.metronome.hotstuff.service.tracing.ConsensusTracers
+import io.iohk.metronome.storage.KVStoreRunner
 import monix.catnap.ConcurrentQueue
 
 /** The `BlockExecutor` receives ranges of committed blocks from the
   * `ConsensusService` and carries out their effects, marking the last
-  * executed block in the `ViewStateStorage`. It delegates other state
-  * updates to the `ApplicationService`.
+  * executed block in the `ViewStateStorage`, so that we can resume
+  * from where we left off last time after a restart.
+  *
+  * It delegates other state updates to the `ApplicationService`.
   *
   * The `BlockExecutor` is prepared for gaps to appear in the ranges,
   * which happens if the node is out of sync with the federation and
@@ -24,23 +32,126 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement](
     blockStorage: BlockStorage[N, A],
     viewStateStorage: ViewStateStorage[N, A],
     executionQueue: ConcurrentQueue[F, Effect.ExecuteBlocks[A]]
-) {
+)(implicit tracers: ConsensusTracers[F, A], storeRunner: KVStoreRunner[F, N]) {
+
+  /** Add a newly committed batch of blocks to the execution queue. */
   def enqueue(effect: Effect.ExecuteBlocks[A]): F[Unit] =
     executionQueue.offer(effect)
 
   /** Execute blocks in order, updating pesistent storage along the way. */
   private def executeBlocks: F[Unit] = {
-    executionQueue.poll.flatMap {
-      case Effect.ExecuteBlocks(lastExecutedBlockHash, commitQC) =>
-        // Retrieve the blocks from the storage from the last executed
-        // to the one in the Quorum Certificate and tell the application
-        // to execute them one by one. Update the persistent view state
-        // after reach execution to remember which blocks we have truly
-        // done.
+    def loop(lastExecutedBlockHash: A#Hash): F[Unit] =
+      executionQueue.poll
+        .flatMap {
+          case Effect.ExecuteBlocks(lastCommittedBlockHash, commitQC) =>
+            // Retrieve the blocks from the storage from the last executed
+            // to the one in the Quorum Certificate and tell the application
+            // to execute them one by one. Update the persistent view state
+            // after reach execution to remember which blocks we have truly
+            // done.
+            getBlockPath(
+              lastExecutedBlockHash,
+              lastCommittedBlockHash,
+              commitQC
+            ).flatMap {
+              case _ :: newBlockHashes =>
+                tryExecuteBatch(newBlockHashes)
 
-        // TODO (PM-3133): Execute block
-        ???
-    } >> executeBlocks
+              case Nil =>
+                none[A#Hash].pure[F]
+            }.map {
+              _ getOrElse lastExecutedBlockHash
+            }
+        }
+        .flatMap(loop)
+
+    storeRunner
+      .runReadOnly {
+        viewStateStorage.getBundle.map(_.lastExecutedBlockHash)
+      }
+      .flatMap(loop)
+  }
+
+  /** Get the more complete path. We may not have the last executed block any more.
+    *
+    * The first hash in the return value is a block that has already been executed.
+    */
+  private def getBlockPath(
+      lastExecutedBlockHash: A#Hash,
+      lastCommittedBlockHash: A#Hash,
+      commitQC: QuorumCertificate[A]
+  ): F[List[A#Hash]] = {
+    def readPath(ancestorBlockHash: A#Hash) =
+      storeRunner
+        .runReadOnly {
+          blockStorage.getPathFromAncestor(
+            lastExecutedBlockHash,
+            commitQC.blockHash
+          )
+        }
+
+    readPath(lastExecutedBlockHash)
+      .flatMap {
+        case Nil =>
+          readPath(lastCommittedBlockHash)
+        case path =>
+          path.pure[F]
+      }
+  }
+
+  /** Try to execute a batch of newly committed blocks.
+    *
+    * Return the last successfully executed hash, if any.
+    */
+  private def tryExecuteBatch(
+      newBlockHashes: List[A#Hash]
+  ): F[Option[A#Hash]] = {
+    def loop(
+        newBlockHashes: List[A#Hash],
+        lastExecutedBlockHash: Option[A#Hash]
+    ): F[Option[A#Hash]] =
+      newBlockHashes match {
+        case Nil =>
+          lastExecutedBlockHash.pure[F]
+
+        case blockHash :: newBlockHashes =>
+          executeBlock(blockHash).attempt.flatMap {
+            case Left(ex) =>
+              // If a block fails, return what we managed to do so far,
+              // so we can re-attempt it next time if the block is still
+              // available in the storage.
+              tracers
+                .error(s"Error executiong block $blockHash", ex)
+                .as(lastExecutedBlockHash)
+
+            case Right(()) =>
+              loop(newBlockHashes, blockHash.some)
+          }
+      }
+
+    loop(newBlockHashes, none)
+  }
+
+  /** Execute the next block in line and update the view state.
+    * Be prepared that it may not exist, if execution took so long that
+    * the `SyncService` skipped ahead to the latest Commit Q.C.
+    */
+  private def executeBlock(blockHash: A#Hash): F[Unit] = {
+    storeRunner.runReadOnly {
+      blockStorage.get(blockHash)
+    } flatMap {
+      case None =>
+        tracers.executionSkipped(blockHash)
+
+      case Some(block) =>
+        for {
+          _ <- appService.executeBlock(block)
+          _ <- storeRunner.runReadWrite {
+            viewStateStorage.setLastExecutedBlockHash(blockHash)
+          }
+          _ <- tracers.blockExecuted(blockHash)
+        } yield ()
+    }
   }
 }
 
@@ -49,6 +160,9 @@ object BlockExecutor {
       appService: ApplicationService[F, A],
       blockStorage: BlockStorage[N, A],
       viewStateStorage: ViewStateStorage[N, A]
+  )(implicit
+      tracers: ConsensusTracers[F, A],
+      storeRunner: KVStoreRunner[F, N]
   ): Resource[F, BlockExecutor[F, N, A]] = for {
     executionQueue <- Resource.liftF {
       ConcurrentQueue[F].unbounded[Effect.ExecuteBlocks[A]](None)

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
@@ -136,11 +136,11 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement](
         case Nil =>
           ().pure[F]
 
-        case blockHash :: newBlockHashes =>
+        case blockHash :: nextBlockHashes =>
           executeBlock(
             blockHash,
             commitQC,
-            NonEmptyList(blockHash, newBlockHashes),
+            NonEmptyList(blockHash, nextBlockHashes),
             lastExecutedBlockHash
           ).attempt.flatMap {
             case Left(ex) =>
@@ -154,10 +154,10 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement](
               // Either the block couldn't be found, or the last executed
               // hash changed, but something suggests that we should not
               // try to execute more of this batch.
-              newBlockHashes.traverse(tracers.executionSkipped(_)).void
+              nextBlockHashes.traverse(tracers.executionSkipped(_)).void
 
             case Right(Some(nextLastExecutedBlockHash)) =>
-              loop(newBlockHashes, nextLastExecutedBlockHash)
+              loop(nextBlockHashes, nextLastExecutedBlockHash)
           }
       }
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
@@ -1,0 +1,66 @@
+package io.iohk.metronome.hotstuff.service.execution
+
+import cats.implicits._
+import cats.effect.{Sync, Concurrent, ContextShift, Resource}
+import io.iohk.metronome.hotstuff.service.ApplicationService
+import io.iohk.metronome.hotstuff.service.storage.{
+  BlockStorage,
+  ViewStateStorage
+}
+import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, Effect}
+import monix.catnap.ConcurrentQueue
+
+/** The `BlockExecutor` receives ranges of committed blocks from the
+  * `ConsensusService` and carries out their effects, marking the last
+  * executed block in the `ViewStateStorage`. It delegates other state
+  * updates to the `ApplicationService`.
+  *
+  * The `BlockExecutor` is prepared for gaps to appear in the ranges,
+  * which happens if the node is out of sync with the federation and
+  * needs to jump ahead.
+  */
+class BlockExecutor[F[_]: Sync, N, A <: Agreement](
+    appService: ApplicationService[F, A],
+    blockStorage: BlockStorage[N, A],
+    viewStateStorage: ViewStateStorage[N, A],
+    executionQueue: ConcurrentQueue[F, Effect.ExecuteBlocks[A]]
+) {
+  def enqueue(effect: Effect.ExecuteBlocks[A]): F[Unit] =
+    executionQueue.offer(effect)
+
+  /** Execute blocks in order, updating pesistent storage along the way. */
+  private def executeBlocks: F[Unit] = {
+    executionQueue.poll.flatMap {
+      case Effect.ExecuteBlocks(lastExecutedBlockHash, commitQC) =>
+        // Retrieve the blocks from the storage from the last executed
+        // to the one in the Quorum Certificate and tell the application
+        // to execute them one by one. Update the persistent view state
+        // after reach execution to remember which blocks we have truly
+        // done.
+
+        // TODO (PM-3133): Execute block
+        ???
+    } >> executeBlocks
+  }
+}
+
+object BlockExecutor {
+  def apply[F[_]: Concurrent: ContextShift, N, A <: Agreement](
+      appService: ApplicationService[F, A],
+      blockStorage: BlockStorage[N, A],
+      viewStateStorage: ViewStateStorage[N, A]
+  ): Resource[F, BlockExecutor[F, N, A]] = for {
+    executionQueue <- Resource.liftF {
+      ConcurrentQueue[F].unbounded[Effect.ExecuteBlocks[A]](None)
+    }
+    executor = new BlockExecutor[F, N, A](
+      appService,
+      blockStorage,
+      viewStateStorage,
+      executionQueue
+    )
+    _ <- Concurrent[F].background {
+      executor.executeBlocks
+    }
+  } yield executor
+}

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
@@ -70,7 +70,7 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement](
     */
   private def getLastExecutedBlockHash: F[A#Hash] =
     storeRunner.runReadOnly {
-      viewStateStorage.getBundle.map(_.lastExecutedBlockHash)
+      viewStateStorage.getLastExecutedBlockHash
     }
 
   private def setLastExecutedBlockHash(blockHash: A#Hash): F[Unit] =

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
@@ -85,7 +85,7 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement](
       storeRunner
         .runReadOnly {
           blockStorage.getPathFromAncestor(
-            lastExecutedBlockHash,
+            ancestorBlockHash,
             commitQC.blockHash
           )
         }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/BlockStorage.scala
@@ -135,21 +135,32 @@ class BlockStorage[N, A <: Agreement: Block](
     *
     * If either of the blocks are not in the tree, or there's no path between them,
     * return an empty list. This can happen if we have already pruned away the ancestry as well.
+    *
+    * The `maxDistance` parameter can be used to limit the maximum traversal depth;
+    * it's useful with blocks that have a `height` field, where we know up front that
+    * if we have ascended more than N blocks from the descendant and haven't encountered
+    * the ancestor, then we must be on a different branch.
     */
   def getPathFromAncestor(
       ancestorBlockHash: A#Hash,
-      descendantBlockHash: A#Hash
+      descendantBlockHash: A#Hash,
+      maxDistance: Int = Int.MaxValue
   ): KVStoreRead[N, List[A#Hash]] = {
     def loop(
         blockHash: A#Hash,
-        acc: List[A#Hash]
+        acc: List[A#Hash],
+        maxDistance: Int
     ): KVStoreRead[N, List[A#Hash]] = {
       if (blockHash == ancestorBlockHash) {
         KVStoreRead[N].pure(blockHash :: acc)
+      } else if (maxDistance == 0) {
+        KVStoreRead[N].pure(Nil)
       } else {
         childToParentColl.read(blockHash).flatMap {
-          case None                  => KVStoreRead[N].pure(Nil)
-          case Some(parentBlockHash) => loop(parentBlockHash, blockHash :: acc)
+          case None =>
+            KVStoreRead[N].pure(Nil)
+          case Some(parentBlockHash) =>
+            loop(parentBlockHash, blockHash :: acc, maxDistance - 1)
         }
       }
     }
@@ -157,7 +168,7 @@ class BlockStorage[N, A <: Agreement: Block](
     (contains(ancestorBlockHash), contains(descendantBlockHash))
       .mapN((_, _))
       .flatMap {
-        case (true, true) => loop(descendantBlockHash, Nil)
+        case (true, true) => loop(descendantBlockHash, Nil, maxDistance)
         case _            => KVStoreRead[N].pure(Nil)
       }
   }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
@@ -44,6 +44,19 @@ class ViewStateStorage[N, A <: Agreement] private (
   def setLastExecutedBlockHash(blockHash: A#Hash): KVStore[N, Unit] =
     put(Key.LastExecutedBlockHash, blockHash)
 
+  /** Set `LastExecutedBlockHash` to `blockHash` if it's still what it was before. */
+  def compareAndSetLastExecutedBlockHash(
+      blockHash: A#Hash,
+      lastExecutedBlockHash: A#Hash
+  ): KVStore[N, Boolean] =
+    read(Key.LastExecutedBlockHash).lift.flatMap { current =>
+      if (current == lastExecutedBlockHash) {
+        setLastExecutedBlockHash(blockHash).as(true)
+      } else {
+        KVStore[N].pure(false)
+      }
+    }
+
   def setRootBlockHash(blockHash: A#Hash): KVStore[N, Unit] =
     put(Key.RootBlockHash, blockHash)
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
@@ -47,7 +47,7 @@ class ViewStateStorage[N, A <: Agreement] private (
   def setRootBlockHash(blockHash: A#Hash): KVStore[N, Unit] =
     put(Key.RootBlockHash, blockHash)
 
-  def getBundle: KVStoreRead[N, ViewStateStorage.Bundle[A]] =
+  val getBundle: KVStoreRead[N, ViewStateStorage.Bundle[A]] =
     (
       read(Key.ViewNumber),
       read(Key.PrepareQC),
@@ -57,6 +57,8 @@ class ViewStateStorage[N, A <: Agreement] private (
       read(Key.RootBlockHash)
     ).mapN(ViewStateStorage.Bundle.apply[A] _)
 
+  val getLastExecutedBlockHash: KVStoreRead[N, A#Hash] =
+    read(Key.LastExecutedBlockHash)
 }
 
 object ViewStateStorage {

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusEvent.scala
@@ -55,8 +55,19 @@ object ConsensusEvent {
       error: ProtocolError[A]
   ) extends ConsensusEvent[A]
 
+  /** A block has been removed from storage by the time it was to be executed. */
+  case class ExecutionSkipped[A <: Agreement](
+      blockHash: A#Hash
+  ) extends ConsensusEvent[A]
+
+  /** A block has been executed. */
+  case class BlockExecuted[A <: Agreement](
+      blockHash: A#Hash
+  ) extends ConsensusEvent[A]
+
   /** An unexpected error in one of the background tasks. */
   case class Error(
+      message: String,
       error: Throwable
   ) extends ConsensusEvent[Nothing]
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusTracers.scala
@@ -22,7 +22,9 @@ case class ConsensusTracers[F[_], A <: Agreement](
     fromFuture: Tracer[F, Event.MessageReceived[A]],
     stashed: Tracer[F, ProtocolError.TooEarly[A]],
     rejected: Tracer[F, ProtocolError[A]],
-    error: Tracer[F, Throwable]
+    executionSkipped: Tracer[F, A#Hash],
+    blockExecuted: Tracer[F, A#Hash],
+    error: Tracer[F, (String, Throwable)]
 )
 
 object ConsensusTracers {
@@ -43,6 +45,8 @@ object ConsensusTracers {
       fromFuture = tracer.contramap[Event.MessageReceived[A]](FromFuture(_)),
       stashed = tracer.contramap[ProtocolError.TooEarly[A]](Stashed(_)),
       rejected = tracer.contramap[ProtocolError[A]](Rejected(_)),
-      error = tracer.contramap[Throwable](Error(_))
+      executionSkipped = tracer.contramap[A#Hash](ExecutionSkipped(_)),
+      blockExecuted = tracer.contramap[A#Hash](BlockExecuted(_)),
+      error = tracer.contramap[(String, Throwable)]((Error.apply _).tupled)
     )
 }

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
@@ -3,7 +3,7 @@ package io.iohk.metronome.hotstuff.service.execution
 import cats.implicits._
 import cats.effect.Resource
 import cats.effect.concurrent.Ref
-import cats.data.NonEmptyVector
+import cats.data.{NonEmptyVector, NonEmptyList}
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
 import io.iohk.metronome.hotstuff.consensus.basic.{
   Effect,
@@ -73,7 +73,11 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
           block: TestBlock
       ): Task[Unit] = ???
 
-      def executeBlock(block: TestBlock): Task[Unit] =
+      def executeBlock(
+          block: TestBlock,
+          commitQC: QuorumCertificate[TestAgreement],
+          commitPath: NonEmptyList[TestAgreement.Hash]
+      ): Task[Unit] =
         for {
           fail <- failNextRef.modify(failNext => (false, failNext))
           _ <- Task

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
@@ -238,7 +238,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
 
   property("executeBlocks - from pruned") = forAll { (fixture: TestFixture) =>
     run {
-      fixture.resources.use { case (blockSychronizer, viewStateStorage) =>
+      fixture.resources.use { case (blockSychronizer, _) =>
         val lastBatch             = fixture.batches.last
         val lastExecutedBlockHash = lastBatch.lastExecutedBlockHash
         for {

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
@@ -81,7 +81,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
         def syncState(
             sources: NonEmptyVector[Int],
             block: TestBlock
-        ): Task[Unit] = ???
+        ): Task[Boolean] = ???
 
         def executeBlock(
             block: TestBlock,

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
@@ -66,8 +66,10 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
     val appService = new ApplicationService[Task, TestAgreement] {
       def createBlock(
           highQC: QuorumCertificate[TestAgreement]
-      ): Task[Option[TestBlock]]                         = ???
-      def validateBlock(block: TestBlock): Task[Boolean] = ???
+      ): Task[Option[TestBlock]] = ???
+
+      def validateBlock(block: TestBlock): Task[Option[Boolean]] = ???
+
       def syncState(
           sources: NonEmptyVector[Int],
           block: TestBlock

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
@@ -79,13 +79,13 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
           block: TestBlock,
           commitQC: QuorumCertificate[TestAgreement],
           commitPath: NonEmptyList[TestAgreement.Hash]
-      ): Task[Unit] =
+      ): Task[Boolean] =
         for {
           fail <- failNextRef.modify(failNext => (false, failNext))
           _ <- Task
             .raiseError(new RuntimeException("The application failed!"))
             .whenA(fail)
-        } yield ()
+        } yield true
     }
 
     val resources =

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
@@ -1,0 +1,164 @@
+package io.iohk.metronome.hotstuff.service.execution
+
+import cats.implicits._
+import cats.effect.Resource
+import cats.effect.concurrent.Ref
+import cats.data.NonEmptyVector
+import io.iohk.metronome.hotstuff.consensus.ViewNumber
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Effect,
+  QuorumCertificate,
+  Phase
+}
+import io.iohk.metronome.crypto.GroupSignature
+import io.iohk.metronome.hotstuff.service.ApplicationService
+import io.iohk.metronome.hotstuff.service.storage.ViewStateStorage
+import io.iohk.metronome.hotstuff.service.storage.{
+  BlockStorageProps,
+  ViewStateStorageCommands
+}
+import io.iohk.metronome.hotstuff.service.tracing.{
+  ConsensusEvent,
+  ConsensusTracers
+}
+import io.iohk.metronome.storage.InMemoryKVStore
+import io.iohk.metronome.tracer.Tracer
+import monix.eval.Task
+import monix.execution.Scheduler
+import org.scalacheck.{Properties, Arbitrary, Gen}
+import org.scalacheck.Prop, Prop.{forAll, propBoolean}
+import scala.concurrent.duration._
+
+object BlockExecutorProps extends Properties("BlockExecutor") {
+  import BlockStorageProps.{
+    TestAgreement,
+    TestBlock,
+    TestBlockStorage,
+    TestKVStore,
+    Namespace,
+    genNonEmptyBlockTree
+  }
+  import ViewStateStorageCommands.neverUsedCodec
+
+  case class TestFixture(
+      blocks: List[TestBlock],
+      batches: List[Effect.ExecuteBlocks[TestAgreement]]
+  ) {
+    val storeRef = Ref.unsafe[Task, TestKVStore.Store] {
+      TestKVStore.build(blocks)
+    }
+    val eventsRef =
+      Ref.unsafe[Task, Vector[ConsensusEvent[TestAgreement]]](Vector.empty)
+
+    val store = InMemoryKVStore[Task, Namespace](storeRef)
+
+    implicit val storeRunner = store
+
+    val eventTracer =
+      Tracer.instance[Task, ConsensusEvent[TestAgreement]] { event =>
+        eventsRef.update(_ :+ event)
+      }
+
+    implicit val consensusTracers = ConsensusTracers(eventTracer)
+
+    val appService = new ApplicationService[Task, TestAgreement] {
+      def createBlock(
+          highQC: QuorumCertificate[TestAgreement]
+      ): Task[Option[TestBlock]]                         = ???
+      def validateBlock(block: TestBlock): Task[Boolean] = ???
+      def syncState(
+          sources: NonEmptyVector[Int],
+          block: TestBlock
+      ): Task[Unit]                                  = ???
+      def executeBlock(block: TestBlock): Task[Unit] = Task.unit
+    }
+
+    val resources =
+      for {
+        viewStateStorage <- Resource.liftF {
+          storeRunner.runReadWrite {
+            val genesisQC = QuorumCertificate[TestAgreement](
+              phase = Phase.Commit,
+              viewNumber = ViewNumber(0),
+              blockHash = blocks.head.id,
+              signature = GroupSignature(())
+            )
+            val genesisBundle = ViewStateStorage.Bundle.fromGenesisQC(genesisQC)
+
+            ViewStateStorage[Namespace, TestAgreement](
+              "view-state",
+              genesisBundle
+            )
+          }
+        }
+        blockExecutor <- BlockExecutor[Task, Namespace, TestAgreement](
+          appService,
+          TestBlockStorage,
+          viewStateStorage
+        )
+      } yield (blockExecutor, viewStateStorage)
+  }
+
+  object TestFixture {
+    implicit val arb: Arbitrary[TestFixture] = Arbitrary {
+      for {
+        ancestorTree <- genNonEmptyBlockTree
+        leaf = ancestorTree.last
+        descendantTree <- genNonEmptyBlockTree(parentId = leaf.id)
+
+        viewNumber <- Gen.posNum[Int].map(ViewNumber(_))
+        descendant <- Gen.oneOf(descendantTree)
+        commitQC = QuorumCertificate[TestAgreement](
+          phase = Phase.Commit,
+          viewNumber = viewNumber,
+          blockHash = descendant.id,
+          signature = GroupSignature(())
+        )
+        effect = Effect.ExecuteBlocks[TestAgreement](
+          lastExecutedBlockHash = leaf.id,
+          quorumCertificate = commitQC
+        )
+
+      } yield TestFixture(
+        ancestorTree ++ descendantTree,
+        List(effect)
+      )
+    }
+  }
+
+  def run(test: Task[Prop]): Prop = {
+    import Scheduler.Implicits.global
+    test.runSyncUnsafe(timeout = 5.seconds)
+  }
+
+  property("executeBlocks") = forAll { (fixture: TestFixture) =>
+    run {
+      fixture.resources.use { case (blockSychronizer, _) =>
+        for {
+          _ <- fixture.batches.traverse(blockSychronizer.enqueue)
+
+          committedBlockHash =
+            fixture.batches.last.quorumCertificate.blockHash
+
+          executedBlockHashes <- fixture.eventsRef.get
+            .map { events =>
+              events.collect { case ConsensusEvent.BlockExecuted(blockHash) =>
+                blockHash
+              }
+            }
+            .restartUntil { blockHashes =>
+              blockHashes.lastOption.contains(committedBlockHash)
+            }
+
+          // The genesis was the only block we marked as executed.
+          pathFromRoot <- fixture.storeRunner.runReadOnly {
+            TestBlockStorage.getPathFromRoot(committedBlockHash)
+          }
+
+        } yield {
+          "executes from root" |: executedBlockHashes == pathFromRoot.tail
+        }
+      }
+    }
+  }
+}

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
@@ -127,7 +127,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
     ): Task[Vector[TestAgreement.Hash]] = {
       executedBlockHashes
         .restartUntil { blockHashes =>
-          blockHashes.lastOption.contains(blockHash)
+          blockHashes.contains(blockHash)
         }
     }
   }


### PR DESCRIPTION
Added a `BlockExecutor` component to farm out the `ExecuteBlocks` effects from the `ConsensusService`. It has an internal work queue where batches are added. A successful execution is noted down in the `ViewStateStorage`. The actual execution is delegated to the `ApplicationService`. If there's an error, we try again next time there's a new batch.

If the `ConsensusService` and the `SyncService` skip ahead to a newer Commit Quroum Certificate, and the last executed block is no longer available, the `BlockExecutor` skips blocks too. Not much else it can do. These events are traced.