### PR TITLE
PM-3241: Fix RocksDB locking to be synchronous.

### DIFF
--- a/metronome/rocksdb/src/io/iohk/metronome/rocksdb/RocksDBStore.scala
+++ b/metronome/rocksdb/src/io/iohk/metronome/rocksdb/RocksDBStore.scala
@@ -140,13 +140,13 @@ class RocksDBStore[F[_]: Sync: ContextShift](
             for {
               kbs <- encode(k)(op.keyEncoder)
               vbs <- encode(v)(op.valueEncoder)
-              _   <- db.put(handles(n), kbs, vbs)
+              _   <- lock.withLockUpgrade(db.put(handles(n), kbs, vbs))
             } yield ()
 
           case op @ Delete(n, k) =>
             for {
               kbs <- encode(k)(op.keyEncoder)
-              _   <- db.delete(handles(n), kbs)
+              _   <- lock.withLockUpgrade(db.delete(handles(n), kbs))
             } yield ()
         }
     }


### PR DESCRIPTION
Discovered as part of testing https://github.com/input-output-hk/metronome/pull/42

I should not have missed this: when using `Task`, multiple operations are executed synchronously in `flatMap` (unlike with `Future` which does everything asynchronously) until the thread yields and processes other tasks. The way locking and unlocking was done was susceptible to the lock being taken on one thread and the unlock attempted on another, resulting in rather elusive deadlocks. In the end I saw `RocksDBStore` mentioned in thread dumps, with threads waiting on read and write locks, and it turned out sometimes it cannot unlock. 

Changed the database to use the `Eval` monad in compiling the `Free` operations, and only at the edge turn them into `F[A]`.