### PR TITLE
[PM-3108] Update Ledger

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -336,7 +336,10 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
 
       object test extends TestModule {
         override def moduleDeps: Seq[JavaModule] =
-          super.moduleDeps ++ Seq(checkpointing.models.test)
+          super.moduleDeps ++ Seq(
+            checkpointing.models.test,
+            hotstuff.service.test
+          )
       }
     }
 

--- a/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/models/Ledger.scala
+++ b/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/models/Ledger.scala
@@ -1,7 +1,5 @@
 package io.iohk.metronome.checkpointing.models
 
-import io.iohk.metronome.core.Validated
-
 /** Current state of the ledger after applying all previous blocks.
   *
   * Basically it's the last checkpoint, plus any accumulated proposer blocks
@@ -21,8 +19,8 @@ case class Ledger(
     * by this point, so we know for example that the new checkpoint is
     * a valid extension of the previous one.
     */
-  def update(transaction: Validated[Transaction]): Ledger =
-    (transaction: Transaction) match {
+  def update(transaction: Transaction): Ledger =
+    transaction match {
       case t @ Transaction.ProposerBlock(_) =>
         if (proposerBlocks.contains(t))
           this
@@ -32,6 +30,9 @@ case class Ledger(
       case t @ Transaction.CheckpointCandidate(_) =>
         Ledger(Some(t), Vector.empty)
     }
+
+  def update(transactions: Iterable[Transaction]): Ledger =
+    transactions.foldLeft(this)(_ update _)
 }
 
 object Ledger extends RLPHashCompanion[Ledger]()(RLPCodecs.rlpLedger) {

--- a/metronome/checkpointing/models/test/src/io/iohk/metronome/checkpointing/models/ArbitraryInstances.scala
+++ b/metronome/checkpointing/models/test/src/io/iohk/metronome/checkpointing/models/ArbitraryInstances.scala
@@ -4,8 +4,11 @@ import cats.data.NonEmptyList
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.metronome.checkpointing.CheckpointingAgreement
 import io.iohk.metronome.crypto.hash.Hash
-import io.iohk.metronome.hotstuff.consensus.basic.Phase
-import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Phase,
+  QuorumCertificate,
+  VotingPhase
+}
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
@@ -95,6 +98,22 @@ object ArbitraryInstances
           ECDSASignature.negativePointSign
         )
       } yield ECDSASignature(r, s, v)
+    }
+
+  implicit val arbQuorumCertificate
+      : Arbitrary[QuorumCertificate[CheckpointingAgreement]] =
+    Arbitrary {
+      for {
+        phase      <- arbitrary[VotingPhase]
+        viewNumber <- arbitrary[ViewNumber]
+        blockHash  <- arbitrary[Block.Header.Hash]
+        signature  <- arbitrary[CheckpointingAgreement.GSig]
+      } yield QuorumCertificate[CheckpointingAgreement](
+        phase,
+        viewNumber,
+        blockHash,
+        GroupSignature(signature)
+      )
     }
 
   implicit val arbCheckpointCertificate: Arbitrary[CheckpointCertificate] =

--- a/metronome/checkpointing/models/test/src/io/iohk/metronome/checkpointing/models/LedgerProps.scala
+++ b/metronome/checkpointing/models/test/src/io/iohk/metronome/checkpointing/models/LedgerProps.scala
@@ -1,6 +1,5 @@
 package io.iohk.metronome.checkpointing.models
 
-import io.iohk.metronome.core.Validated
 import org.scalacheck._
 import org.scalacheck.Prop.forAll
 
@@ -8,7 +7,7 @@ object LedgerProps extends Properties("Ledger") {
   import ArbitraryInstances._
 
   property("update") = forAll { (ledger: Ledger, transaction: Transaction) =>
-    val updated = ledger.update(Validated[Transaction](transaction))
+    val updated = ledger.update(transaction)
 
     transaction match {
       case _: Transaction.ProposerBlock
@@ -21,7 +20,7 @@ object LedgerProps extends Properties("Ledger") {
           updated.maybeLastCheckpoint == ledger.maybeLastCheckpoint
 
       case _: Transaction.CheckpointCandidate =>
-        updated.maybeLastCheckpoint == Some(transaction) &&
+        updated.maybeLastCheckpoint.contains(transaction) &&
           updated.proposerBlocks.isEmpty
     }
   }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
@@ -1,0 +1,239 @@
+package io.iohk.metronome.checkpointing.service
+
+import cats.data.{NonEmptyList, NonEmptyVector, OptionT}
+import cats.effect.concurrent.Ref
+import cats.effect.{Concurrent, Resource, Sync}
+import cats.implicits._
+import io.iohk.metronome.checkpointing.CheckpointingAgreement
+import io.iohk.metronome.checkpointing.models.{
+  Block,
+  CheckpointCertificate,
+  Ledger
+}
+import io.iohk.metronome.checkpointing.service.CheckpointingService.LedgerTree
+import io.iohk.metronome.checkpointing.service.storage.LedgerStorage
+import io.iohk.metronome.crypto.ECPublicKey
+import io.iohk.metronome.hotstuff.consensus.basic.{Phase, QuorumCertificate}
+import io.iohk.metronome.hotstuff.service.ApplicationService
+import io.iohk.metronome.hotstuff.service.storage.{
+  BlockStorage,
+  ViewStateStorage
+}
+import io.iohk.metronome.storage.KVStoreRunner
+
+import scala.annotation.tailrec
+
+class CheckpointingService[F[_]: Sync, N](
+    ledgerTree: Ref[F, LedgerTree],
+    lastExecutedHeader: Ref[F, Block.Header],
+    ledgerStorage: LedgerStorage[N],
+    blockStorage: BlockStorage[N, CheckpointingAgreement]
+)(implicit storeRunner: KVStoreRunner[F, N])
+    extends ApplicationService[F, CheckpointingAgreement] {
+
+  override def createBlock(
+      highQC: QuorumCertificate[CheckpointingAgreement]
+  ): F[Option[Block]] = ???
+
+  override def validateBlock(block: Block): F[Option[Boolean]] = {
+    val ledgers = for {
+      nextLedger <- OptionT(projectLedger(block))
+      tree       <- OptionT.liftF(ledgerTree.get)
+      prevLedger <- tree.get(block.header.parentHash).map(_._1).toOptionT[F]
+    } yield (prevLedger, nextLedger)
+
+    ledgers.value.flatMap {
+      case Some((prevLedger, nextLedger))
+          if nextLedger.hash == block.header.postStateHash =>
+        validateTransactions(block.body, prevLedger)
+
+      case _ => false.some.pure[F]
+    }
+  }
+
+  private def validateTransactions(
+      body: Block.Body,
+      ledger: Ledger
+  ): F[Option[Boolean]] = {
+    //TODO: Validate transactions PM-3131/3132
+    true.some.pure[F]
+  }
+
+  override def executeBlock(
+      block: Block,
+      commitQC: QuorumCertificate[CheckpointingAgreement],
+      commitPath: NonEmptyList[Block.Hash]
+  ): F[Boolean] = {
+    require(commitQC.phase == Phase.Commit, "Commit QC required")
+    projectLedger(block).flatMap {
+      case Some(ledger) =>
+        if (block.hash != commitQC.blockHash)
+          saveLedger(block.header, ledger).as(true)
+        else
+          for {
+            //TODO: PM-3110:
+            // chkpOpt <- constructCheckpoint(ledger, commitQC)
+            _ <- saveLedger(block.header, ledger)
+            //TODO: PM-3110:
+            // _ <- chkpOpt.map(pushCheckpoint).getOrElse(().pure[F])
+          } yield true
+
+      case None =>
+        Sync[F].raiseError(
+          new IllegalStateException(s"Could not execute block: ${block.hash}")
+        )
+    }
+  }
+
+  private def projectLedger(block: Block): F[Option[Ledger]] = {
+    (for {
+      ledgers    <- ledgerTree.get
+      execHeight <- lastExecutedHeader.get.map(_.height)
+    } yield {
+      def loop(block: Block): OptionT[F, Ledger] = {
+        def doUpdate(ledger: Ledger) =
+          OptionT.liftF(updateLedgerByBlock(ledger, block))
+
+        ledgers.get(block.header.parentHash) match {
+          case Some((oldLedger, _)) =>
+            doUpdate(oldLedger)
+
+          case None if block.header.height <= execHeight =>
+            OptionT.none
+
+          case None =>
+            for {
+              parent    <- OptionT(getBlock(block.header.parentHash))
+              oldLedger <- loop(parent)
+              newLedger <- doUpdate(oldLedger)
+            } yield newLedger
+        }
+      }
+
+      ledgers
+        .get(block.hash)
+        .map(_._1)
+        .toOptionT[F]
+        .orElse(loop(block))
+        .value
+    }).flatten
+  }
+
+  private def updateLedgerByBlock(
+      oldLedger: Ledger,
+      block: Block
+  ): F[Ledger] = {
+    val newLedger = oldLedger.update(block.body.transactions)
+    ledgerTree
+      .update { tree =>
+        if (tree.contains(block.header.parentHash))
+          tree + (block.hash -> (newLedger, block.header))
+        else
+          tree
+      }
+      .as(newLedger)
+  }
+
+  private def getBlock(hash: Block.Hash): F[Option[Block]] =
+    storeRunner.runReadOnly(blockStorage.get(hash))
+
+  private def saveLedger(header: Block.Header, ledger: Ledger): F[Unit] = {
+    storeRunner.runReadWrite {
+      ledgerStorage.put(ledger)
+    } >>
+      ledgerTree.update(clearLedgerTree(header, ledger)) >>
+      lastExecutedHeader.set(header)
+  }
+
+  /** Makes the `commitHeader` and the associated 'ledger' the root of the tree,
+    * while retaining any descendants of the `commitHeader`
+    */
+  private def clearLedgerTree(commitHeader: Block.Header, ledger: Ledger)(
+      ledgerTree: LedgerTree
+  ): LedgerTree = {
+
+    @tailrec
+    def loop(
+        oldTree: LedgerTree,
+        newTree: LedgerTree,
+        height: Long
+    ): LedgerTree =
+      if (oldTree.isEmpty) newTree
+      else {
+        val (higherLevels, currentLevel) = oldTree.partition {
+          case (_, (_, hd)) => hd.height > height
+        }
+        val children = currentLevel.filter { case (_, (_, hd)) =>
+          newTree.contains(hd.parentHash)
+        }
+        loop(higherLevels, newTree ++ children, height + 1)
+      }
+
+    loop(
+      ledgerTree.filter { case (_, (_, hd)) =>
+        hd.height > commitHeader.height
+      },
+      Map(commitHeader.hash -> (ledger, commitHeader)),
+      commitHeader.height + 1
+    )
+  }
+
+  private def constructCheckpoint(
+      ledger: Ledger,
+      commitQC: QuorumCertificate[CheckpointingAgreement]
+  ): F[Option[CheckpointCertificate]] =
+    ??? //TODO: PM-3110
+
+  private def pushCheckpoint(checkpoint: CheckpointCertificate): F[Unit] =
+    ??? //TODO: PM-3137
+
+  override def syncState(
+      sources: NonEmptyVector[ECPublicKey],
+      block: Block
+  ): F[Boolean] = ???
+}
+
+object CheckpointingService {
+  type LedgerTree = Map[Block.Hash, (Ledger, Block.Header)]
+
+  def apply[F[_]: Concurrent, N](
+      ledgerStorage: LedgerStorage[N],
+      blockStorage: BlockStorage[N, CheckpointingAgreement],
+      viewStateStorage: ViewStateStorage[N, CheckpointingAgreement]
+  )(implicit
+      storeRunner: KVStoreRunner[F, N]
+  ): Resource[F, CheckpointingService[F, N]] = {
+    val lastExecuted: F[(Block, Ledger)] =
+      storeRunner.runReadOnly {
+        val query = for {
+          blockHash <- OptionT.liftF(
+            viewStateStorage.getLastExecutedBlockHash
+          )
+          block <- OptionT(blockStorage.get(blockHash))
+          //a genesis (empty) state should be present in LedgerStorage on first run
+          ledger <- OptionT(ledgerStorage.get(block.header.postStateHash))
+        } yield (block, ledger)
+        query.value
+      } >>= {
+        _.toOptionT[F].getOrElseF {
+          Sync[F].raiseError(
+            new IllegalStateException("Last executed block/state not found")
+          )
+        }
+      }
+
+    val service = for {
+      (block, ledger) <- lastExecuted
+      ledgerTree      <- Ref.of(Map(block.hash -> (ledger, block.header)))
+      lastExec        <- Ref.of(block.header)
+    } yield new CheckpointingService[F, N](
+      ledgerTree,
+      lastExec,
+      ledgerStorage,
+      blockStorage
+    )
+
+    Resource.liftF(service)
+  }
+
+}

--- a/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceProps.scala
+++ b/metronome/checkpointing/service/test/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceProps.scala
@@ -1,0 +1,405 @@
+package io.iohk.metronome.checkpointing.service
+
+import cats.data.NonEmptyList
+import cats.effect.Resource
+import cats.effect.concurrent.Ref
+import cats.implicits._
+import io.iohk.metronome.checkpointing.CheckpointingAgreement
+import io.iohk.metronome.checkpointing.models.Block.{Hash, Header}
+import io.iohk.metronome.checkpointing.models.{
+  ArbitraryInstances,
+  Block,
+  Ledger
+}
+import io.iohk.metronome.checkpointing.service.CheckpointingService.LedgerTree
+import io.iohk.metronome.checkpointing.service.storage.LedgerStorage
+import io.iohk.metronome.checkpointing.service.storage.LedgerStorageProps.{
+  neverUsedCodec,
+  Namespace => LedgerNamespace
+}
+import io.iohk.metronome.hotstuff.consensus.basic.Phase.Commit
+import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import io.iohk.metronome.hotstuff.service.storage.BlockStorage
+import io.iohk.metronome.hotstuff.service.storage.BlockStorageProps.{
+  Namespace => BlockNamespace
+}
+import io.iohk.metronome.storage.{
+  InMemoryKVStore,
+  KVCollection,
+  KVStoreRunner,
+  KVStoreState,
+  KVTree
+}
+import monix.eval.Task
+import monix.execution.Scheduler
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.{all, classify, forAll, forAllNoShrink, propBoolean}
+import org.scalacheck.{Gen, Prop, Properties}
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+class CheckpointingServiceProps extends Properties("CheckpointingService") {
+
+  type Namespace = String
+
+  case class TestResources(
+      checkpointingService: CheckpointingService[Task, Namespace],
+      ledgerStorage: LedgerStorage[Namespace],
+      blockStorage: BlockStorage[Namespace, CheckpointingAgreement],
+      store: KVStoreRunner[Task, Namespace],
+      ledgerTreeRef: Ref[Task, LedgerTree]
+  )
+
+  case class TestFixture(
+      initialBlock: Block,
+      initialLedger: Ledger,
+      batch: List[Block],
+      commitQC: QuorumCertificate[CheckpointingAgreement]
+  ) {
+    val resources: Resource[Task, TestResources] = {
+      val ledgerStorage =
+        new LedgerStorage[Namespace](
+          new KVCollection[Namespace, Ledger.Hash, Ledger](
+            LedgerNamespace.Ledgers
+          ),
+          LedgerNamespace.LedgerMeta,
+          maxHistorySize = 10
+        )
+
+      val blockStorage = new BlockStorage[Namespace, CheckpointingAgreement](
+        new KVCollection[Namespace, Block.Hash, Block](BlockNamespace.Blocks),
+        new KVCollection[Namespace, Block.Hash, KVTree.NodeMeta[Hash]](
+          BlockNamespace.BlockMetas
+        ),
+        new KVCollection[Namespace, Block.Hash, Set[Block.Hash]](
+          BlockNamespace.BlockToChildren
+        )
+      )
+
+      implicit val store = InMemoryKVStore[Task, Namespace](
+        Ref.unsafe[Task, KVStoreState[Namespace]#Store](Map.empty)
+      )
+
+      Resource.liftF {
+        for {
+          _ <- store.runReadWrite {
+            ledgerStorage.put(initialLedger.hash, initialLedger) >>
+              blockStorage.put(initialBlock)
+          }
+
+          ledgerTree <- Ref.of[Task, LedgerTree](
+            Map(initialBlock.hash -> (initialLedger, initialBlock.header))
+          )
+          lastExec <- Ref.of[Task, Header](initialBlock.header)
+
+          service = new CheckpointingService[Task, Namespace](
+            ledgerTree,
+            lastExec,
+            ledgerStorage,
+            blockStorage
+          )
+
+        } yield TestResources(
+          service,
+          ledgerStorage,
+          blockStorage,
+          store,
+          ledgerTree
+        )
+      }
+    }
+
+    // not used in the impl so a senseless value
+    val commitPath = NonEmptyList.one(initialBlock.header.parentHash)
+
+    val allTransactions = batch.flatMap(_.body.transactions)
+    val finalLedger     = initialLedger.update(allTransactions)
+  }
+
+  object TestFixture {
+    import ArbitraryInstances._
+
+    def gen(minChain: Int = 1): Gen[TestFixture] = {
+      for {
+        block <- arbitrary[Block]
+        ledger = Ledger.empty.update(block.body.transactions)
+        batch    <- genBlockChain(block, ledger, min = minChain)
+        commitQC <- genCommitQC(batch.last)
+      } yield TestFixture(block, ledger, batch, commitQC)
+    }
+
+    def genBlockChain(
+        parent: Block,
+        initialLedger: Ledger,
+        min: Int = 1,
+        max: Int = 6
+    ): Gen[List[Block]] = {
+      for {
+        n      <- Gen.choose(min, max)
+        blocks <- Gen.listOfN(n, arbitrary[Block])
+      } yield {
+        def link(
+            parent: Block,
+            prevLedger: Ledger,
+            chain: List[Block]
+        ): List[Block] = chain match {
+          case b :: bs =>
+            val nextLedger = prevLedger.update(b.body.transactions)
+            val header = b.header.copy(
+              parentHash = parent.hash,
+              height = parent.header.height + 1,
+              postStateHash = nextLedger.hash
+            )
+            val linked = Block.makeUnsafe(header, b.body)
+            linked :: link(linked, nextLedger, bs)
+          case Nil =>
+            Nil
+        }
+
+        link(parent, initialLedger, blocks)
+      }
+    }
+
+    def genCommitQC(
+        block: Block
+    ): Gen[QuorumCertificate[CheckpointingAgreement]] =
+      arbitrary[QuorumCertificate[CheckpointingAgreement]].map {
+        _.copy[CheckpointingAgreement](phase = Commit, blockHash = block.hash)
+      }
+  }
+
+  def run(fixture: TestFixture)(test: TestResources => Task[Prop]): Prop = {
+    import Scheduler.Implicits.global
+
+    fixture.resources.use(test).runSyncUnsafe(timeout = 5.seconds)
+  }
+
+  property("normal execution") = forAll(TestFixture.gen()) { fixture =>
+    run(fixture) { res =>
+      import fixture._
+      import res._
+
+      val execution = batch
+        .map(checkpointingService.executeBlock(_, commitQC, commitPath))
+        .sequence
+
+      val ledgerStorageCheck = store.runReadOnly {
+        ledgerStorage.get(finalLedger.hash)
+      }
+
+      for {
+        results         <- execution
+        persistedLedger <- ledgerStorageCheck
+        ledgerTree      <- ledgerTreeRef.get
+      } yield {
+        val ledgerTreeUpdated = ledgerTree == Map(
+          batch.last.hash -> (finalLedger, batch.last.header)
+        )
+
+        all(
+          "execution successful" |: results.reduce(_ && _),
+          "ledger persisted" |: persistedLedger.contains(finalLedger),
+          "ledgerTree updated" |: ledgerTreeUpdated
+        )
+      }
+    }
+  }
+
+  property("failed execution - no parent") =
+    forAll(TestFixture.gen(minChain = 2)) { fixture =>
+      run(fixture) { res =>
+        import fixture._
+        import res._
+
+        // parent block or its state is not saved so this must fail
+        val execution = batch.tail
+          .map(checkpointingService.executeBlock(_, commitQC, commitPath))
+          .sequence
+
+        execution.attempt.map {
+          case Left(ex: IllegalStateException) =>
+            ex.getMessage.contains("Could not execute block")
+          case _ => false
+        }
+      }
+    }
+
+  property("failed execution - height below last executed") =
+    forAll(TestFixture.gen(minChain = 2)) { fixture =>
+      run(fixture) { res =>
+        import fixture._
+        import res._
+
+        val execution = batch
+          .map(checkpointingService.executeBlock(_, commitQC, commitPath))
+          .sequence
+
+        // repeated execution must fail because we're trying to execute a block of lower height
+        // than the last executed block
+        execution >>
+          execution.attempt.map {
+            case Left(ex: IllegalStateException) =>
+              ex.getMessage.contains("Could not execute block")
+            case _ => false
+          }
+      }
+    }
+
+  //TODO: Validate transactions PM-3131/3132
+  //      use a mocked interpreter client that always evaluates blocks as valid
+  property("parallel validation") = forAll(TestFixture.gen(minChain = 4)) {
+    fixture =>
+      run(fixture) { res =>
+        import fixture._
+        import res._
+
+        // validation in random order so blocks need to be persisted first
+        val persistBlocks = store.runReadWrite {
+          batch.map(blockStorage.put).sequence
+        }
+
+        def validation(
+            validating: Ref[Task, Boolean],
+            achievedPar: Ref[Task, Boolean]
+        ) =
+          Task.parSequence {
+            Random
+              .shuffle(batch)
+              .map(b =>
+                for {
+                  v <- validating.getAndSet(true)
+                  _ <- achievedPar.update(_ || v)
+                  r <- checkpointingService.validateBlock(b)
+                  _ <- validating.set(false)
+                } yield r.getOrElse(false)
+              )
+          }
+
+        for {
+          _ <- persistBlocks
+
+          // used to make sure that parallelism was achieved
+          validating  <- Ref[Task].of(false)
+          achievedPar <- Ref[Task].of(false)
+
+          result     <- validation(validating, achievedPar)
+          par        <- achievedPar.get
+          ledgerTree <- ledgerTreeRef.get
+        } yield {
+          val ledgerTreeUpdated = batch.forall(b => ledgerTree.contains(b.hash))
+
+          classify(par, "parallelism achieved") {
+            all(
+              "validation successful" |: result.forall(identity),
+              "ledgerTree updated" |: ledgerTreeUpdated
+            )
+          }
+        }
+      }
+  }
+
+  //TODO: Validate transactions PM-3131/3132
+  //      use a mocked interpreter client that always evaluates blocks as valid
+  property("execution parallel to validation") = forAllNoShrink {
+    for {
+      f   <- TestFixture.gen(minChain = 4)
+      ext <- TestFixture.genBlockChain(f.batch.last, f.finalLedger)
+    } yield (f, f.batch ++ ext)
+  } { case (fixture, validationBatch) =>
+    run(fixture) { res =>
+      import fixture._
+      import res._
+
+      // validation in random order so blocks need to be persisted first
+      val persistBlocks = store.runReadWrite {
+        validationBatch.map(blockStorage.put).sequence
+      }
+
+      def validation(
+          validating: Ref[Task, Boolean],
+          executing: Ref[Task, Boolean],
+          achievedPar: Ref[Task, Boolean]
+      ) =
+        Random
+          .shuffle(validationBatch)
+          .map(b =>
+            for {
+              _ <- validating.set(true)
+              e <- executing.get
+              _ <- achievedPar.update(_ || e)
+              r <- checkpointingService.validateBlock(b)
+              _ <- validating.set(false)
+            } yield (r.getOrElse(false), b.header.height)
+          )
+          .sequence
+
+      def execution(
+          validating: Ref[Task, Boolean],
+          executing: Ref[Task, Boolean],
+          achievedPar: Ref[Task, Boolean]
+      ) =
+        batch
+          .map(b =>
+            for {
+              _ <- executing.set(true)
+              v <- validating.get
+              _ <- achievedPar.update(_ || v)
+              r <- checkpointingService.executeBlock(b, commitQC, commitPath)
+              _ <- executing.set(false)
+            } yield r
+          )
+          .sequence
+
+      val ledgerStorageCheck = store.runReadOnly {
+        ledgerStorage.get(finalLedger.hash)
+      }
+
+      for {
+        _ <- persistBlocks
+
+        // used to make sure that parallelism was achieved
+        validating  <- Ref[Task].of(false)
+        executing   <- Ref[Task].of(false)
+        achievedPar <- Ref[Task].of(false)
+
+        (validationRes, executionRes) <- Task.parZip2(
+          validation(validating, executing, achievedPar),
+          execution(validating, executing, achievedPar)
+        )
+
+        par             <- achievedPar.get
+        persistedLedger <- ledgerStorageCheck
+        ledgerTree      <- ledgerTreeRef.get
+      } yield {
+        val validationsAfterExec = validationRes.collect {
+          case (r, h) if h > batch.last.header.height => r
+        }
+
+        val ledgerTreeReset = batch.reverse match {
+          case committed :: rest =>
+            ledgerTree
+              .get(committed.hash)
+              .contains((finalLedger, committed.header)) &&
+              rest.forall(b => !ledgerTree.contains(b.hash))
+
+          case _ => false
+        }
+
+        val validationsSaved =
+          validationBatch.diff(batch).forall(b => ledgerTree.contains(b.hash))
+
+        classify(par, "parallelism achieved") {
+          all(
+            "validation successful" |: validationsAfterExec.forall(identity),
+            "execution successful" |: executionRes.forall(identity),
+            "ledger persisted" |: persistedLedger.contains(finalLedger),
+            "ledgerTree reset" |: ledgerTreeReset,
+            "ledgerTree contains validations" |: validationsSaved
+          )
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
The motivation is that since in the normal flow a block is first validated and the resulting state is saved in memory then it should not be necessary for `BlockExecutor` to prepare a batch of blocks to execute. The chosen design however should work with or without it. Having the intermediate Ledgers saved in memory should not require any additional queries to the persistent storage during execution, as long as the service run uninterrupted.

The in memory map of Ledgers should always hold the last committed state, being reset to that single value after each commit. The associated block headers can be used to construct the checkpoint certificate. 