### PR TITLE
PM-3133: Make Quorum Certificate generic in Phase 

### DIFF
--- a/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/models/CheckpointCertificate.scala
+++ b/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/models/CheckpointCertificate.scala
@@ -1,7 +1,7 @@
 package io.iohk.metronome.checkpointing.models
 
 import cats.data.NonEmptyList
-import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import io.iohk.metronome.hotstuff.consensus.basic.{QuorumCertificate, Phase}
 import io.iohk.metronome.checkpointing.CheckpointingAgreement
 
 /** The Checkpoint Certificate is a proof of the BFT agreement
@@ -26,5 +26,5 @@ case class CheckpointCertificate(
     // Proof that `checkpoint` is part of `headers.last.contentMerkleRoot`.
     proof: MerkleTree.Proof,
     // Commit Q.C. over `headers.head`.
-    commitQC: QuorumCertificate[CheckpointingAgreement]
+    commitQC: QuorumCertificate[CheckpointingAgreement, Phase.Commit]
 )

--- a/metronome/checkpointing/models/test/src/io/iohk/metronome/checkpointing/models/ArbitraryInstances.scala
+++ b/metronome/checkpointing/models/test/src/io/iohk/metronome/checkpointing/models/ArbitraryInstances.scala
@@ -111,7 +111,7 @@ object ArbitraryInstances
 
         viewNumber <- Gen.posNum[Long].map(x => ViewNumber(x + n))
         signature  <- arbitrary[CheckpointingAgreement.GSig]
-        commitQC = QuorumCertificate[CheckpointingAgreement](
+        commitQC = QuorumCertificate[CheckpointingAgreement, Phase.Commit](
           phase = Phase.Commit,
           viewNumber = viewNumber,
           blockHash = headers.head.hash,

--- a/metronome/checkpointing/models/test/src/io/iohk/metronome/checkpointing/models/RLPCodecsSpec.scala
+++ b/metronome/checkpointing/models/test/src/io/iohk/metronome/checkpointing/models/RLPCodecsSpec.scala
@@ -168,7 +168,7 @@ class RLPCodecsSpec extends AnyFlatSpec with Matchers {
           leafIndex = 2,
           siblingPath = Vector(sample[MerkleTree.Hash], sample[MerkleTree.Hash])
         ),
-        commitQC = QuorumCertificate[CheckpointingAgreement](
+        commitQC = QuorumCertificate[CheckpointingAgreement, Phase.Commit](
           phase = Phase.Commit,
           viewNumber = ViewNumber(10),
           blockHash = sample[Block.Header.Hash],

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Effect.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Effect.scala
@@ -43,7 +43,7 @@ object Effect {
     */
   case class CreateBlock[A <: Agreement](
       viewNumber: ViewNumber,
-      highQC: QuorumCertificate[A]
+      highQC: QuorumCertificate[A, Phase.Prepare]
   ) extends Effect[A]
 
   /** Once the Prepare Q.C. has been established for a block,
@@ -67,7 +67,7 @@ object Effect {
     */
   case class ExecuteBlocks[A <: Agreement](
       lastExecutedBlockHash: A#Hash,
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, Phase.Commit]
   ) extends Effect[A]
 
 }

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Event.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Event.scala
@@ -21,6 +21,6 @@ object Event {
       viewNumber: ViewNumber,
       block: A#Block,
       // The certificate which the block extended.
-      highQC: QuorumCertificate[A]
+      highQC: QuorumCertificate[A, Phase.Prepare]
   ) extends Event[A]
 }

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Message.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Message.scala
@@ -24,7 +24,7 @@ object Message {
   case class Prepare[A <: Agreement](
       viewNumber: ViewNumber,
       block: A#Block,
-      highQC: QuorumCertificate[A]
+      highQC: QuorumCertificate[A, Phase.Prepare]
   ) extends LeaderMessage[A]
 
   /** Having received one of the leader messages, the replica
@@ -54,9 +54,9 @@ object Message {
     *
     * The certificate contains the hash of the block to vote on.
     */
-  case class Quorum[A <: Agreement](
+  case class Quorum[A <: Agreement, P <: VotingPhase](
       viewNumber: ViewNumber,
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, P]
   ) extends LeaderMessage[A]
 
   /** At the end of the round, replicas send the `NewView` message
@@ -64,6 +64,6 @@ object Message {
     */
   case class NewView[A <: Agreement](
       viewNumber: ViewNumber,
-      prepareQC: QuorumCertificate[A]
+      prepareQC: QuorumCertificate[A, Phase.Prepare]
   ) extends ReplicaMessage[A]
 }

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Phase.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Phase.scala
@@ -46,4 +46,8 @@ object Phase {
   case object PreCommit extends VotingPhase
   case object Commit    extends VotingPhase
   case object Decide    extends Phase
+
+  type Prepare   = Prepare.type
+  type PreCommit = PreCommit.type
+  type Commit    = Commit.type
 }

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolError.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolError.scala
@@ -32,7 +32,7 @@ object ProtocolError {
   /** The Q.C. signature doesn't match the content. */
   case class InvalidQuorumCertificate[A <: Agreement](
       sender: A#PKey,
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, VotingPhase]
   ) extends ProtocolError[A]
 
   /** The block in the prepare message doesn't extend the previous Q.C. */

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/QuorumCertificate.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/QuorumCertificate.scala
@@ -2,13 +2,42 @@ package io.iohk.metronome.hotstuff.consensus.basic
 
 import io.iohk.metronome.crypto.GroupSignature
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
+import scala.reflect.ClassTag
 
 /** A Quorum Certifcate (QC) over a tuple (message-type, view-number, block-hash) is a data type
   * that combines a collection of signatures for the same tuple signed by (n − f) replicas.
   */
-case class QuorumCertificate[A <: Agreement](
-    phase: VotingPhase,
+case class QuorumCertificate[A <: Agreement, +P <: VotingPhase](
+    phase: P,
     viewNumber: ViewNumber,
     blockHash: A#Hash,
     signature: GroupSignature[A#PKey, (VotingPhase, ViewNumber, A#Hash), A#GSig]
-)
+) {
+  def coerce[V <: VotingPhase](implicit
+      ct: ClassTag[V]
+  ): QuorumCertificate[A, V] = {
+    // assert(ct.unapply(phase).isDefined) // Not always true in testing.
+    this.asInstanceOf[QuorumCertificate[A, V]]
+  }
+  protected[basic] def withPhase[V <: VotingPhase](phase: V) =
+    copy[A, V](phase = phase)
+
+  protected[basic] def withViewNumber(viewNumber: ViewNumber) =
+    copy[A, P](viewNumber = viewNumber)
+
+  protected[basic] def withBlockHash(blockHash: A#Hash) =
+    copy[A, P](blockHash = blockHash)
+
+  protected[basic] def withSignature(
+      signature: GroupSignature[
+        A#PKey,
+        (VotingPhase, ViewNumber, A#Hash),
+        A#GSig
+      ]
+  ) =
+    copy[A, P](signature = signature)
+
+  // Sometimes when we have just `QuorumCertificate[A, _]` the compiler
+  // can't prove that `.phase` is a `VotingPhase` and not just `$1`.
+  protected[basic] def votingPhase: VotingPhase = phase
+}

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Signing.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Signing.scala
@@ -50,12 +50,12 @@ trait Signing[A <: Agreement] {
 
   def validate(
       federation: Federation[A#PKey],
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, _]
   ): Boolean =
     validate(
       federation,
       quorumCertificate.signature,
-      quorumCertificate.phase,
+      quorumCertificate.votingPhase,
       quorumCertificate.viewNumber,
       quorumCertificate.blockHash
     )

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
@@ -1,14 +1,20 @@
 package io.iohk.metronome.hotstuff.service
 
 import cats.data.{NonEmptyVector, NonEmptyList}
-import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Agreement,
+  QuorumCertificate,
+  Phase
+}
 
 /** Represents the "application" domain to the HotStuff module,
   * performing all delegations that HotStuff can't do on its own.
   */
 trait ApplicationService[F[_], A <: Agreement] {
   // TODO (PM-3109): Create block.
-  def createBlock(highQC: QuorumCertificate[A]): F[Option[A#Block]]
+  def createBlock(
+      highQC: QuorumCertificate[A, Phase.Prepare]
+  ): F[Option[A#Block]]
 
   // TODO (PM-3132, PM-3133): Block validation.
   // Returns None if validation cannot be carried out due to data availability issues within a given timeout.
@@ -22,7 +28,7 @@ trait ApplicationService[F[_], A <: Agreement] {
   // proof of the BFT agreement at the end.
   def executeBlock(
       block: A#Block,
-      commitQC: QuorumCertificate[A],
+      commitQC: QuorumCertificate[A, Phase.Commit],
       commitPath: NonEmptyList[A#Hash]
   ): F[Unit]
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -140,7 +140,7 @@ class ConsensusService[
         // Let the ProtocolState reject it if it's not about the prepared block.
         enqueueEvent(message)
 
-      case _: Quorum[_] =>
+      case _: Quorum[_, _] =>
         // Let the ProtocolState reject it if it's not about the prepared block.
         enqueueEvent(message)
 
@@ -314,7 +314,9 @@ class ConsensusService[
         viewStateStorage.setViewNumber(viewNumber)
       }
 
-  private def updateQuorum(quorumCertificate: QuorumCertificate[A]): F[Unit] =
+  private def updateQuorum(
+      quorumCertificate: QuorumCertificate[A, _]
+  ): F[Unit] =
     tracers.quorum(quorumCertificate) >>
       storeRunner.runReadWrite {
         viewStateStorage.setQuorumCertificate(quorumCertificate)

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
@@ -1,7 +1,11 @@
 package io.iohk.metronome.hotstuff.service
 
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
-import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Agreement,
+  QuorumCertificate,
+  Phase
+}
 
 /** Status has all the fields necessary for nodes to sync with each other.
   *
@@ -10,6 +14,6 @@ import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
   */
 case class Status[A <: Agreement](
     viewNumber: ViewNumber,
-    prepareQC: QuorumCertificate[A],
-    commitQC: QuorumCertificate[A]
+    prepareQC: QuorumCertificate[A, Phase.Prepare],
+    commitQC: QuorumCertificate[A, Phase.Commit]
 )

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
@@ -11,7 +11,8 @@ import io.iohk.metronome.hotstuff.service.storage.{
 import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
   Effect,
-  QuorumCertificate
+  QuorumCertificate,
+  Phase
 }
 import io.iohk.metronome.hotstuff.service.tracing.ConsensusTracers
 import io.iohk.metronome.storage.KVStoreRunner
@@ -97,7 +98,7 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement](
   private def getBlockPath(
       lastExecutedBlockHash: A#Hash,
       lastCommittedBlockHash: A#Hash,
-      commitQC: QuorumCertificate[A]
+      commitQC: QuorumCertificate[A, Phase.Commit]
   ): F[List[A#Hash]] = {
     def readPath(ancestorBlockHash: A#Hash) =
       storeRunner
@@ -123,7 +124,7 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement](
     */
   private def tryExecuteBatch(
       newBlockHashes: List[A#Hash],
-      commitQC: QuorumCertificate[A],
+      commitQC: QuorumCertificate[A, Phase.Commit],
       lastExecutedBlockHash: A#Hash
   ): F[A#Hash] = {
     def loop(
@@ -163,7 +164,7 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement](
     */
   private def executeBlock(
       blockHash: A#Hash,
-      commitQC: QuorumCertificate[A],
+      commitQC: QuorumCertificate[A, Phase.Commit],
       commitPath: NonEmptyList[A#Hash],
       lastExecutedBlockHash: A#Hash
   ): F[Unit] = {

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
@@ -5,10 +5,12 @@ import io.iohk.metronome.hotstuff.consensus.ViewNumber
 import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
   QuorumCertificate,
-  Phase
+  Phase,
+  VotingPhase
 }
 import io.iohk.metronome.storage.{KVStore, KVStoreRead}
-import scodec.{Codec, Encoder, Decoder}
+import scodec.{Codec, Encoder, Decoder, Attempt, Err}
+import scala.reflect.ClassTag
 
 class ViewStateStorage[N, A <: Agreement] private (
     namespace: N
@@ -17,10 +19,14 @@ class ViewStateStorage[N, A <: Agreement] private (
     kvn: KVStore.Ops[N],
     kvrn: KVStoreRead.Ops[N],
     codecVN: Codec[ViewNumber],
-    codecQC: Codec[QuorumCertificate[A]],
+    codecQC: Codec[QuorumCertificate[A, _]],
     codecH: Codec[A#Hash]
 ) {
   import keys.Key
+
+  private implicit def decodeQCP[P <: VotingPhase: ClassTag]
+      : Decoder[QuorumCertificate[A, P]] =
+    ViewStateStorage.codecQCP[A, P].asDecoder
 
   private def put[V: Encoder](key: Key[V], value: V) =
     KVStore[N].put[Key[V], V](namespace, key, value)
@@ -31,14 +37,14 @@ class ViewStateStorage[N, A <: Agreement] private (
   def setViewNumber(viewNumber: ViewNumber): KVStore[N, Unit] =
     put(Key.ViewNumber, viewNumber)
 
-  def setQuorumCertificate(qc: QuorumCertificate[A]): KVStore[N, Unit] =
+  def setQuorumCertificate(qc: QuorumCertificate[A, _]): KVStore[N, Unit] =
     qc.phase match {
       case Phase.Prepare =>
-        put(Key.PrepareQC, qc)
+        put(Key.PrepareQC, qc.coerce[Phase.Prepare])
       case Phase.PreCommit =>
-        put(Key.LockedQC, qc)
+        put(Key.LockedQC, qc.coerce[Phase.PreCommit])
       case Phase.Commit =>
-        put(Key.CommitQC, qc)
+        put(Key.CommitQC, qc.coerce[Phase.Commit])
     }
 
   def setLastExecutedBlockHash(blockHash: A#Hash): KVStore[N, Unit] =
@@ -76,6 +82,25 @@ class ViewStateStorage[N, A <: Agreement] private (
 
 object ViewStateStorage {
 
+  implicit def codecQCP[A <: Agreement, P <: VotingPhase](implicit
+      ev: Codec[QuorumCertificate[A, _]],
+      ct: ClassTag[P]
+  ) = ev.exmap[QuorumCertificate[A, P]](
+    qc =>
+      ct.unapply(qc.phase)
+        .map { _ =>
+          Attempt.successful(qc.coerce[P])
+        }
+        .getOrElse {
+          Attempt.failure(
+            Err(
+              s"Unexpected phase: ${qc.phase}; wanted ${ct.runtimeClass.getSimpleName}"
+            )
+          )
+        },
+    qc => Attempt.successful(qc)
+  )
+
   /** Storing elements of the view state individually under separate keys,
     * because they get written independently.
     */
@@ -83,9 +108,9 @@ object ViewStateStorage {
     sealed abstract class Key[V](private val code: Int)
     object Key {
       case object ViewNumber            extends Key[ViewNumber](0)
-      case object PrepareQC             extends Key[QuorumCertificate[A]](1)
-      case object LockedQC              extends Key[QuorumCertificate[A]](2)
-      case object CommitQC              extends Key[QuorumCertificate[A]](3)
+      case object PrepareQC             extends Key[QuorumCertificate[A, Phase.Prepare]](1)
+      case object LockedQC              extends Key[QuorumCertificate[A, Phase.PreCommit]](2)
+      case object CommitQC              extends Key[QuorumCertificate[A, Phase.Commit]](3)
       case object LastExecutedBlockHash extends Key[A#Hash](4)
       case object RootBlockHash         extends Key[A#Hash](5)
 
@@ -102,9 +127,9 @@ object ViewStateStorage {
     */
   case class Bundle[A <: Agreement](
       viewNumber: ViewNumber,
-      prepareQC: QuorumCertificate[A],
-      lockedQC: QuorumCertificate[A],
-      commitQC: QuorumCertificate[A],
+      prepareQC: QuorumCertificate[A, Phase.Prepare],
+      lockedQC: QuorumCertificate[A, Phase.PreCommit],
+      commitQC: QuorumCertificate[A, Phase.Commit],
       lastExecutedBlockHash: A#Hash,
       rootBlockHash: A#Hash
   ) {
@@ -118,12 +143,12 @@ object ViewStateStorage {
       * in the genesis Q.C. will not depend on the phase, just the genesis
       * hash.
       */
-    def fromGenesisQC[A <: Agreement](genesisQC: QuorumCertificate[A]) =
+    def fromGenesisQC[A <: Agreement](genesisQC: QuorumCertificate[A, _]) =
       Bundle[A](
         viewNumber = genesisQC.viewNumber,
-        prepareQC = genesisQC.copy[A](phase = Phase.Prepare),
-        lockedQC = genesisQC.copy[A](phase = Phase.PreCommit),
-        commitQC = genesisQC.copy[A](phase = Phase.Commit),
+        prepareQC = genesisQC.copy[A, Phase.Prepare](phase = Phase.Prepare),
+        lockedQC = genesisQC.copy[A, Phase.PreCommit](phase = Phase.PreCommit),
+        commitQC = genesisQC.copy[A, Phase.Commit](phase = Phase.Commit),
         lastExecutedBlockHash = genesisQC.blockHash,
         rootBlockHash = genesisQC.blockHash
       )
@@ -137,7 +162,7 @@ object ViewStateStorage {
       genesis: Bundle[A]
   )(implicit
       codecVN: Codec[ViewNumber],
-      codecQC: Codec[QuorumCertificate[A]],
+      codecQC: Codec[QuorumCertificate[A, _]],
       codecH: Codec[A#Hash]
   ): KVStore[N, ViewStateStorage[N, A]] = {
     implicit val kvn  = KVStore.instance[N]

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
@@ -63,7 +63,7 @@ class BlockSynchronizer[F[_]: Sync: Timer, N, A <: Agreement: Block](
     */
   def sync(
       sender: A#PKey,
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, _]
   ): F[Unit] =
     for {
       path <- download(sender, quorumCertificate.blockHash, Nil)
@@ -84,7 +84,7 @@ class BlockSynchronizer[F[_]: Sync: Timer, N, A <: Agreement: Block](
     */
   def getBlockFromQuorumCertificate(
       sources: NonEmptyVector[A#PKey],
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, _]
   ): F[Either[DownloadFailedException[A], A#Block]] = {
     val otherSources = sources.filterNot(_ == publicKey).toList
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusEvent.scala
@@ -6,7 +6,10 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   Event,
   ProtocolError
 }
-import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  QuorumCertificate,
+  VotingPhase
+}
 import io.iohk.metronome.hotstuff.service.ConsensusService.MessageCounter
 import io.iohk.metronome.hotstuff.service.Status
 
@@ -34,8 +37,9 @@ object ConsensusEvent {
   case class NewView(viewNumber: ViewNumber) extends ConsensusEvent[Nothing]
 
   /** Quorum over some block. */
-  case class Quorum[A <: Agreement](quorumCertificate: QuorumCertificate[A])
-      extends ConsensusEvent[A]
+  case class Quorum[A <: Agreement](
+      quorumCertificate: QuorumCertificate[A, VotingPhase]
+  ) extends ConsensusEvent[A]
 
   /** A formally valid message was received from an earlier view number. */
   case class FromPast[A <: Agreement](message: Event.MessageReceived[A])

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusTracers.scala
@@ -7,7 +7,8 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
   Event,
   ProtocolError,
-  QuorumCertificate
+  QuorumCertificate,
+  VotingPhase
 }
 import io.iohk.metronome.hotstuff.service.ConsensusService.MessageCounter
 import io.iohk.metronome.hotstuff.service.Status
@@ -17,7 +18,7 @@ case class ConsensusTracers[F[_], A <: Agreement](
     viewSync: Tracer[F, ViewNumber],
     adoptView: Tracer[F, Status[A]],
     newView: Tracer[F, ViewNumber],
-    quorum: Tracer[F, QuorumCertificate[A]],
+    quorum: Tracer[F, QuorumCertificate[A, _]],
     fromPast: Tracer[F, Event.MessageReceived[A]],
     fromFuture: Tracer[F, Event.MessageReceived[A]],
     stashed: Tracer[F, ProtocolError.TooEarly[A]],
@@ -40,7 +41,9 @@ object ConsensusTracers {
       viewSync = tracer.contramap[ViewNumber](ViewSync(_)),
       adoptView = tracer.contramap[Status[A]](AdoptView(_)),
       newView = tracer.contramap[ViewNumber](NewView(_)),
-      quorum = tracer.contramap[QuorumCertificate[A]](Quorum(_)),
+      quorum = tracer.contramap[QuorumCertificate[A, _]](qc =>
+        Quorum(qc.coerce[VotingPhase])
+      ),
       fromPast = tracer.contramap[Event.MessageReceived[A]](FromPast(_)),
       fromFuture = tracer.contramap[Event.MessageReceived[A]](FromFuture(_)),
       stashed = tracer.contramap[ProtocolError.TooEarly[A]](Stashed(_)),

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -4,7 +4,6 @@ import io.iohk.metronome.core.Validated
 import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, ProtocolError}
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 import io.iohk.metronome.hotstuff.service.Status
-import io.iohk.metronome.hotstuff.consensus.basic.ProtocolError
 
 sealed trait SyncEvent[+A <: Agreement]
 

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/MessageStashSpec.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/MessageStashSpec.scala
@@ -35,7 +35,7 @@ class MessageStashSpec extends AnyFlatSpec with Matchers {
         "Alice",
         Message.NewView(
           ViewNumber(10),
-          QuorumCertificate[TestAgreement](
+          QuorumCertificate[TestAgreement, Phase.Prepare](
             Phase.Prepare,
             ViewNumber(9),
             123,
@@ -63,7 +63,7 @@ class MessageStashSpec extends AnyFlatSpec with Matchers {
         error.event.copy(message =
           Message.NewView(
             ViewNumber(10),
-            QuorumCertificate[TestAgreement](
+            QuorumCertificate[TestAgreement, Phase.Prepare](
               Phase.Prepare,
               ViewNumber(8),
               122,

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
@@ -65,7 +65,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
 
     val appService = new ApplicationService[Task, TestAgreement] {
       def createBlock(
-          highQC: QuorumCertificate[TestAgreement]
+          highQC: QuorumCertificate[TestAgreement, Phase.Prepare]
       ): Task[Option[TestBlock]] = ???
 
       def validateBlock(block: TestBlock): Task[Option[Boolean]] = ???
@@ -77,7 +77,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
 
       def executeBlock(
           block: TestBlock,
-          commitQC: QuorumCertificate[TestAgreement],
+          commitQC: QuorumCertificate[TestAgreement, Phase.Commit],
           commitPath: NonEmptyList[TestAgreement.Hash]
       ): Task[Unit] =
         for {
@@ -92,7 +92,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
       for {
         viewStateStorage <- Resource.liftF {
           storeRunner.runReadWrite {
-            val genesisQC = QuorumCertificate[TestAgreement](
+            val genesisQC = QuorumCertificate[TestAgreement, Phase.Commit](
               phase = Phase.Commit,
               viewNumber = ViewNumber(0),
               blockHash = blocks.head.id,
@@ -154,7 +154,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
             ancestor = tree.last
             descendantTree <- genNonEmptyBlockTree(parentId = ancestor.id)
             descendant = descendantTree.last
-            commitQC = QuorumCertificate[TestAgreement](
+            commitQC = QuorumCertificate[TestAgreement, Phase.Commit](
               phase = Phase.Commit,
               viewNumber = viewNumber,
               blockHash = descendant.id,

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorageProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorageProps.scala
@@ -16,6 +16,7 @@ import scala.util.Try
 import scodec.bits.BitVector
 import scodec.Codec
 import scala.util.Success
+import io.iohk.metronome.hotstuff.consensus.basic.VotingPhase
 
 object ViewStateStorageProps extends Properties("ViewStateStorage") {
   property("commands") = ViewStateStorageCommands.property()
@@ -63,7 +64,7 @@ object ViewStateStorageCommands extends Commands {
 
   val genesisState = ViewStateStorage.Bundle
     .fromGenesisQC[TestAgreement] {
-      QuorumCertificate[TestAgreement](
+      QuorumCertificate[TestAgreement, Phase.Prepare](
         Phase.Prepare,
         ViewNumber(1),
         "",
@@ -119,7 +120,7 @@ object ViewStateStorageCommands extends Commands {
       p <- Gen.oneOf(Phase.Prepare, Phase.PreCommit, Phase.Commit)
       h <- arbitrary[TestAgreement.Hash]
       s <- arbitrary[TestAgreement.GSig]
-      qc = QuorumCertificate[TestAgreement](
+      qc = QuorumCertificate[TestAgreement, VotingPhase](
         p,
         state.viewNumber,
         h,
@@ -157,16 +158,20 @@ object ViewStateStorageCommands extends Commands {
     override def postCondition(state: State, success: Boolean): Prop = success
   }
 
-  case class SetQuorumCertificateCommand(qc: QuorumCertificate[TestAgreement])
-      extends UnitCommand {
+  case class SetQuorumCertificateCommand(
+      qc: QuorumCertificate[TestAgreement, VotingPhase]
+  ) extends UnitCommand {
     override def run(sut: Sut): Result =
       sut.write(_.setQuorumCertificate(qc))
 
     override def nextState(state: State): State =
       qc.phase match {
-        case Phase.Prepare   => state.copy(prepareQC = qc)
-        case Phase.PreCommit => state.copy(lockedQC = qc)
-        case Phase.Commit    => state.copy(commitQC = qc)
+        case Phase.Prepare =>
+          state.copy(prepareQC = qc.coerce[Phase.Prepare])
+        case Phase.PreCommit =>
+          state.copy(lockedQC = qc.coerce[Phase.PreCommit])
+        case Phase.Commit =>
+          state.copy(commitQC = qc.coerce[Phase.Commit])
       }
 
     override def preCondition(state: State): Boolean =

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizerProps.scala
@@ -9,7 +9,11 @@ import io.iohk.metronome.hotstuff.consensus.{
   Federation,
   LeaderSelection
 }
-import io.iohk.metronome.hotstuff.consensus.basic.{QuorumCertificate, Phase}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  QuorumCertificate,
+  Phase,
+  VotingPhase
+}
 import io.iohk.metronome.hotstuff.service.storage.BlockStorageProps
 import io.iohk.metronome.storage.InMemoryKVStore
 import org.scalacheck.{Properties, Arbitrary, Gen, Prop}, Arbitrary.arbitrary
@@ -45,7 +49,9 @@ object BlockSynchronizerProps extends Properties("BlockSynchronizer") {
   case class TestFixture(
       ancestorTree: List[TestBlock],
       descendantTree: List[TestBlock],
-      requests: List[(TestAgreement.PKey, QuorumCertificate[TestAgreement])],
+      requests: List[
+        (TestAgreement.PKey, QuorumCertificate[TestAgreement, VotingPhase])
+      ],
       federation: Federation[TestAgreement.PKey],
       random: Random,
       timeoutProb: Prob,
@@ -127,7 +133,7 @@ object BlockSynchronizerProps extends Properties("BlockSynchronizer") {
 
         requests = (prepares zip proposerKeys).zipWithIndex.map {
           case ((parent, publicKey), idx) =>
-            publicKey -> QuorumCertificate[TestAgreement](
+            publicKey -> QuorumCertificate[TestAgreement, Phase.Prepare](
               phase = Phase.Prepare,
               viewNumber = ViewNumber(100L + idx),
               blockHash = parent.id,

--- a/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/test/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -116,12 +116,12 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
       rounds: Int,
       federation: Federation[TestAgreement.PKey],
       byzantines: Set[TestAgreement.PKey],
-      genesisQC: QuorumCertificate[TestAgreement]
+      genesisQC: QuorumCertificate[TestAgreement, Phase.Prepare]
   ): Gen[Responses] = {
 
-    def genQC(
+    def genQC[P <: VotingPhase](
         viewNumber: ViewNumber,
-        phase: VotingPhase,
+        phase: P,
         blockHash: TestAgreement.Hash
     ) =
       for {
@@ -138,7 +138,7 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
           )
         }
         groupSig = mockSigning.combine(partialSigs)
-      } yield QuorumCertificate[TestAgreement](
+      } yield QuorumCertificate[TestAgreement, P](
         phase,
         viewNumber,
         blockHash,
@@ -146,13 +146,13 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
       )
 
     /** Extend a Q.C. by building a new block on top of it. */
-    def genPrepareQC(qc: QuorumCertificate[TestAgreement]) =
+    def genPrepareQC(qc: QuorumCertificate[TestAgreement, _]) =
       genHash.flatMap { blockHash =>
         genQC(qc.viewNumber.next, Phase.Prepare, blockHash)
       }
 
     /** Extend a Q.C. by committing the block in it. */
-    def genCommitQC(qc: QuorumCertificate[TestAgreement]) =
+    def genCommitQC(qc: QuorumCertificate[TestAgreement, _]) =
       genQC(qc.viewNumber, Phase.Commit, qc.blockHash)
 
     def genInvalid(status: Status[TestAgreement]) = {
@@ -160,11 +160,11 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
         Gen.delay(Gen.const(invalid))
       Gen.oneOf(
         delay(status.copy(viewNumber = status.prepareQC.viewNumber.prev)),
-        delay(status.copy(prepareQC = status.commitQC)),
-        delay(status.copy(commitQC = status.prepareQC)),
+        delay(status.copy(prepareQC = status.commitQC.coerce[Phase.Prepare])),
+        delay(status.copy(commitQC = status.prepareQC.coerce[Phase.Commit])),
         delay(
           status.copy(commitQC =
-            status.commitQC.copy[TestAgreement](signature =
+            status.commitQC.copy[TestAgreement, Phase.Commit](signature =
               status.commitQC.signature
                 .copy(sig = status.commitQC.signature.sig.map(_ + 1))
             )
@@ -175,15 +175,15 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
 
     def loop(
         round: Int,
-        prepareQC: QuorumCertificate[TestAgreement],
-        commitQC: QuorumCertificate[TestAgreement],
+        prepareQC: QuorumCertificate[TestAgreement, Phase.Prepare],
+        commitQC: QuorumCertificate[TestAgreement, Phase.Commit],
         accum: Responses
     ): Gen[Responses] =
       if (round == rounds) Gen.const(accum)
       else {
         val keepCommit = Gen.const(commitQC)
 
-        def maybeCommit(qc: QuorumCertificate[TestAgreement]) =
+        def maybeCommit(qc: QuorumCertificate[TestAgreement, _]) =
           if (qc.blockHash != commitQC.blockHash) genCommitQC(qc)
           else keepCommit
 
@@ -225,7 +225,7 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
     loop(
       0,
       genesisQC,
-      genesisQC.copy[TestAgreement](phase = Phase.Commit),
+      genesisQC.copy[TestAgreement, Phase.Commit](phase = Phase.Commit),
       Vector.empty
     )
   }


### PR DESCRIPTION
The result of a PR discussion, positing whether we should have separate `QuorumCertificate` types for each phase, to get rid of some assertions. 

Made `QuorumCertificate` generic in `P <: VotingPhase`, so we can state which kind we must have in certain fields or method parameters.