### PR TITLE
PM-3353: Make Quorum Certificate generic in Phase

### DIFF
--- a/metronome/checkpointing/models/props/src/io/iohk/metronome/checkpointing/models/ArbitraryInstances.scala
+++ b/metronome/checkpointing/models/props/src/io/iohk/metronome/checkpointing/models/ArbitraryInstances.scala
@@ -101,14 +101,14 @@ object ArbitraryInstances
     }
 
   implicit val arbQuorumCertificate
-      : Arbitrary[QuorumCertificate[CheckpointingAgreement]] =
+      : Arbitrary[QuorumCertificate[CheckpointingAgreement, VotingPhase]] =
     Arbitrary {
       for {
         phase      <- arbitrary[VotingPhase]
         viewNumber <- arbitrary[ViewNumber]
         blockHash  <- arbitrary[Block.Header.Hash]
         signature  <- arbitrary[CheckpointingAgreement.GSig]
-      } yield QuorumCertificate[CheckpointingAgreement](
+      } yield QuorumCertificate[CheckpointingAgreement, VotingPhase](
         phase,
         viewNumber,
         blockHash,

--- a/metronome/checkpointing/models/props/src/io/iohk/metronome/checkpointing/models/ArbitraryInstances.scala
+++ b/metronome/checkpointing/models/props/src/io/iohk/metronome/checkpointing/models/ArbitraryInstances.scala
@@ -132,7 +132,7 @@ object ArbitraryInstances
 
         viewNumber <- Gen.posNum[Long].map(x => ViewNumber(x + n))
         signature  <- arbitrary[CheckpointingAgreement.GSig]
-        commitQC = QuorumCertificate[CheckpointingAgreement](
+        commitQC = QuorumCertificate[CheckpointingAgreement, Phase.Commit](
           phase = Phase.Commit,
           viewNumber = viewNumber,
           blockHash = headers.head.hash,

--- a/metronome/checkpointing/models/specs/src/io/iohk/metronome/checkpointing/models/RLPCodecsSpec.scala
+++ b/metronome/checkpointing/models/specs/src/io/iohk/metronome/checkpointing/models/RLPCodecsSpec.scala
@@ -168,7 +168,7 @@ class RLPCodecsSpec extends AnyFlatSpec with Matchers {
           leafIndex = 2,
           siblingPath = Vector(sample[MerkleTree.Hash], sample[MerkleTree.Hash])
         ),
-        commitQC = QuorumCertificate[CheckpointingAgreement](
+        commitQC = QuorumCertificate[CheckpointingAgreement, Phase.Commit](
           phase = Phase.Commit,
           viewNumber = ViewNumber(10),
           blockHash = sample[Block.Header.Hash],

--- a/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/models/CheckpointCertificate.scala
+++ b/metronome/checkpointing/models/src/io/iohk/metronome/checkpointing/models/CheckpointCertificate.scala
@@ -1,7 +1,7 @@
 package io.iohk.metronome.checkpointing.models
 
 import cats.data.NonEmptyList
-import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import io.iohk.metronome.hotstuff.consensus.basic.{QuorumCertificate, Phase}
 import io.iohk.metronome.checkpointing.CheckpointingAgreement
 import io.iohk.metronome.checkpointing.models.Transaction.CheckpointCandidate
 
@@ -27,14 +27,14 @@ case class CheckpointCertificate(
     // Proof that `checkpoint` is part of `headers.head.contentMerkleRoot`.
     proof: MerkleTree.Proof,
     // Commit Q.C. over `headers.last`.
-    commitQC: QuorumCertificate[CheckpointingAgreement]
+    commitQC: QuorumCertificate[CheckpointingAgreement, Phase.Commit]
 )
 
 object CheckpointCertificate {
   def construct(
       block: Block,
       headers: NonEmptyList[Block.Header],
-      commitQC: QuorumCertificate[CheckpointingAgreement]
+      commitQC: QuorumCertificate[CheckpointingAgreement, Phase.Commit]
   ): Option[CheckpointCertificate] =
     constructProof(block).map { case (proof, cp) =>
       CheckpointCertificate(headers, cp, proof, commitQC)

--- a/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceProps.scala
+++ b/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceProps.scala
@@ -23,7 +23,7 @@ import io.iohk.metronome.checkpointing.service.storage.LedgerStorageProps.{
   neverUsedCodec,
   Namespace => LedgerNamespace
 }
-import io.iohk.metronome.hotstuff.consensus.basic.Phase.Commit
+import io.iohk.metronome.hotstuff.consensus.basic.Phase
 import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
 import io.iohk.metronome.hotstuff.service.storage.BlockStorage
 import io.iohk.metronome.hotstuff.service.storage.BlockStorageProps.{
@@ -44,6 +44,7 @@ import org.scalacheck.{Gen, Prop, Properties}
 
 import scala.concurrent.duration._
 import scala.util.Random
+import io.iohk.metronome.hotstuff.consensus.basic.VotingPhase
 
 /** Props for Checkpointing service
   *
@@ -70,7 +71,7 @@ class CheckpointingServiceProps extends Properties("CheckpointingService") {
       initialBlock: Block,
       initialLedger: Ledger,
       batch: List[Block],
-      commitQC: QuorumCertificate[CheckpointingAgreement],
+      commitQC: QuorumCertificate[CheckpointingAgreement, Phase.Commit],
       randomSeed: Long
   ) {
     val resources: Resource[Task, TestResources] = {
@@ -198,9 +199,12 @@ class CheckpointingServiceProps extends Properties("CheckpointingService") {
 
     def genCommitQC(
         block: Block
-    ): Gen[QuorumCertificate[CheckpointingAgreement]] =
-      arbitrary[QuorumCertificate[CheckpointingAgreement]].map {
-        _.copy[CheckpointingAgreement](phase = Commit, blockHash = block.hash)
+    ): Gen[QuorumCertificate[CheckpointingAgreement, Phase.Commit]] =
+      arbitrary[QuorumCertificate[CheckpointingAgreement, VotingPhase]].map {
+        _.copy[CheckpointingAgreement, Phase.Commit](
+          phase = Phase.Commit,
+          blockHash = block.hash
+        )
       }
   }
 

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
@@ -41,7 +41,7 @@ class CheckpointingService[F[_]: Sync, N](
     extends ApplicationService[F, CheckpointingAgreement] {
 
   override def createBlock(
-      highQC: QuorumCertificate[CheckpointingAgreement]
+      highQC: QuorumCertificate[CheckpointingAgreement, Phase.Prepare]
   ): F[Option[Block]] = ???
 
   override def validateBlock(block: Block): F[Option[Boolean]] = {
@@ -70,7 +70,7 @@ class CheckpointingService[F[_]: Sync, N](
 
   override def executeBlock(
       block: Block,
-      commitQC: QuorumCertificate[CheckpointingAgreement],
+      commitQC: QuorumCertificate[CheckpointingAgreement, Phase.Commit],
       commitPath: NonEmptyList[Block.Hash]
   ): F[Boolean] = {
     require(commitQC.phase == Phase.Commit, "Commit QC required")

--- a/metronome/examples/src/io/iohk/metronome/examples/robot/app/RobotComposition.scala
+++ b/metronome/examples/src/io/iohk/metronome/examples/robot/app/RobotComposition.scala
@@ -339,7 +339,7 @@ trait RobotComposition {
   protected def makeViewStateStorage(genesis: RobotBlock)(implicit
       storeRunner: KVStoreRunner[Task, NS]
   ) = Resource.liftF {
-    val genesisQC = QuorumCertificate[RobotAgreement](
+    val genesisQC = QuorumCertificate[RobotAgreement, Phase.Prepare](
       phase = Phase.Prepare,
       viewNumber = ViewNumber(0),
       blockHash = genesis.hash,

--- a/metronome/examples/src/io/iohk/metronome/examples/robot/models/RobotSigning.scala
+++ b/metronome/examples/src/io/iohk/metronome/examples/robot/models/RobotSigning.scala
@@ -22,7 +22,7 @@ class RobotSigning(
     */
   override def validate(
       federation: Federation[RobotAgreement.PKey],
-      quorumCertificate: QuorumCertificate[RobotAgreement]
+      quorumCertificate: QuorumCertificate[RobotAgreement, _]
   ): Boolean =
     if (quorumCertificate.blockHash == genesisHash) {
       quorumCertificate.signature.sig.isEmpty

--- a/metronome/examples/src/io/iohk/metronome/examples/robot/models/RobotSigning.scala
+++ b/metronome/examples/src/io/iohk/metronome/examples/robot/models/RobotSigning.scala
@@ -7,6 +7,7 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   QuorumCertificate,
   Secp256k1Signing
 }
+import io.iohk.metronome.hotstuff.consensus.basic.VotingPhase
 
 class RobotSigning(
     genesisHash: RobotAgreement.Hash
@@ -22,7 +23,7 @@ class RobotSigning(
     */
   override def validate(
       federation: Federation[RobotAgreement.PKey],
-      quorumCertificate: QuorumCertificate[RobotAgreement, _]
+      quorumCertificate: QuorumCertificate[RobotAgreement, VotingPhase]
   ): Boolean =
     if (quorumCertificate.blockHash == genesisHash) {
       quorumCertificate.signature.sig.isEmpty

--- a/metronome/examples/src/io/iohk/metronome/examples/robot/service/RobotService.scala
+++ b/metronome/examples/src/io/iohk/metronome/examples/robot/service/RobotService.scala
@@ -10,7 +10,7 @@ import io.iohk.metronome.examples.robot.RobotAgreement
 import io.iohk.metronome.examples.robot.models.{RobotBlock, Robot}
 import io.iohk.metronome.examples.robot.service.messages.RobotMessage
 import io.iohk.metronome.examples.robot.service.tracing.RobotTracers
-import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import io.iohk.metronome.hotstuff.consensus.basic.{QuorumCertificate, Phase}
 import io.iohk.metronome.hotstuff.service.ApplicationService
 import io.iohk.metronome.hotstuff.service.storage.{
   BlockStorage,
@@ -38,7 +38,7 @@ class RobotService[F[_]: Sync: Timer, N](
 
   /** Make a random valid move on top of the last block. */
   override def createBlock(
-      highQC: QuorumCertificate[RobotAgreement]
+      highQC: QuorumCertificate[RobotAgreement, Phase.Prepare]
   ): F[Option[RobotBlock]] = {
     val parentState = for {
       parent <- OptionT {
@@ -146,7 +146,7 @@ class RobotService[F[_]: Sync: Timer, N](
   /** Execute the next block in the queue, store the resulting state. */
   override def executeBlock(
       block: RobotBlock,
-      commitQC: QuorumCertificate[RobotAgreement],
+      commitQC: QuorumCertificate[RobotAgreement, Phase.Commit],
       commitPath: NonEmptyList[RobotAgreement.Hash]
   ): F[Boolean] =
     projectState(block.parentHash).flatMap {

--- a/metronome/hotstuff/consensus/props/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
+++ b/metronome/hotstuff/consensus/props/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
@@ -47,7 +47,7 @@ object ProtocolStateCommands extends Commands {
   val genesis =
     TestBlock(blockHash = 0, parentBlockHash = -1, command = "")
 
-  val genesisQC = QuorumCertificate[TestAgreement](
+  val genesisQC = QuorumCertificate[TestAgreement, Phase.Prepare](
     phase = Phase.Prepare,
     viewNumber = ViewNumber(0),
     blockHash = genesis.blockHash,
@@ -153,8 +153,8 @@ object ProtocolStateCommands extends Commands {
       ownIndex: Int,
       votesFrom: Set[TestAgreement.PKey],
       newViewsFrom: Set[TestAgreement.PKey],
-      newViewsHighQC: QuorumCertificate[TestAgreement],
-      prepareQCs: List[QuorumCertificate[TestAgreement]],
+      newViewsHighQC: QuorumCertificate[TestAgreement, Phase.Prepare],
+      prepareQCs: List[QuorumCertificate[TestAgreement, Phase.Prepare]],
       maybeBlockHash: Option[TestAgreement.Hash]
   ) {
     def publicKey = federation(ownIndex)
@@ -188,7 +188,8 @@ object ProtocolStateCommands extends Commands {
       state.votesFrom.isEmpty &&
       state.newViewsFrom.isEmpty
 
-  override def newSut(state: State): Sut =
+  override def newSut(state: State): Sut = {
+    import Phase._
     new Protocol(
       ProtocolState[TestAgreement](
         viewNumber = ViewNumber(state.viewNumber),
@@ -198,14 +199,15 @@ object ProtocolStateCommands extends Commands {
         federation = Federation(state.federation, state.f)
           .getOrElse(sys.error("Invalid federation!")),
         prepareQC = genesisQC,
-        lockedQC = genesisQC,
-        commitQC = genesisQC,
+        lockedQC = genesisQC.copy[TestAgreement, PreCommit](phase = PreCommit),
+        commitQC = genesisQC.copy[TestAgreement, Commit](phase = Commit),
         preparedBlock = genesis,
         timeout = 10.seconds,
         votes = Set.empty,
         newViews = Map.empty
       )
     )
+  }
 
   override def destroySut(sut: Sut): Unit = ()
 
@@ -313,24 +315,25 @@ object ProtocolStateCommands extends Commands {
     def invalidSender                         = state.federation.sum + 1
 
     def invalidateQC(
-        qc: QuorumCertificate[TestAgreement]
-    ): Gen[QuorumCertificate[TestAgreement]] = {
+        qc: QuorumCertificate[TestAgreement, _]
+    ): Gen[QuorumCertificate[TestAgreement, _]] = {
       Gen.oneOf(
         genLazy(
-          qc.copy[TestAgreement](blockHash = invalidateHash(qc.blockHash))
-        ),
-        genLazy(qc.copy[TestAgreement](phase = nextVoting(qc.phase)))
-          .suchThat(_.blockHash != genesisQC.blockHash),
-        genLazy(
-          qc.copy[TestAgreement](viewNumber =
-            invalidateViewNumber(qc.viewNumber)
-          )
+          qc.withBlockHash(invalidateHash(qc.blockHash)).coerce[VotingPhase]
         ),
         genLazy(
-          qc.copy[TestAgreement](signature =
+          qc.withPhase(nextVoting(qc.phase.asInstanceOf[VotingPhase]))
+            .coerce[VotingPhase]
+        ).suchThat(_.blockHash != genesisQC.blockHash),
+        genLazy(
+          qc.withViewNumber(invalidateViewNumber(qc.viewNumber))
+            .coerce[VotingPhase]
+        ),
+        genLazy(
+          qc.withSignature(
             // The quorum cert has no items, so add one to make it different.
             qc.signature.copy(sig = 0L +: qc.signature.sig.map(invalidateSig))
-          )
+          ).coerce[VotingPhase]
         )
       )
     }
@@ -352,7 +355,7 @@ object ProtocolStateCommands extends Commands {
                 )
               ),
               "prepareQC" ! invalidateQC(m.prepareQC).map { qc =>
-                cmd.copy(message = m.copy(prepareQC = qc))
+                cmd.copy(message = m.copy(prepareQC = qc.coerce[Phase.Prepare]))
               }
             )
 
@@ -373,7 +376,7 @@ object ProtocolStateCommands extends Commands {
                 )
               ),
               "highQC" ! invalidateQC(m.highQC).map { qc =>
-                cmd.copy(message = m.copy(highQC = qc))
+                cmd.copy(message = m.copy(highQC = qc.coerce[Phase.Prepare]))
               }
             )
 
@@ -409,10 +412,12 @@ object ProtocolStateCommands extends Commands {
           case cmd @ QuorumCmd(_, m) =>
             Gen.oneOf(
               "sender" ! genLazy(cmd.copy(sender = invalidSender)),
-              "quorumCertificate" ! invalidateQC(m.quorumCertificate).map {
-                qc =>
-                  cmd.copy(message = m.copy(quorumCertificate = qc))
-              }
+              "quorumCertificate" ! invalidateQC(m.quorumCertificate)
+                .map { qc =>
+                  cmd.copy(message =
+                    m.copy(quorumCertificate = qc.coerce[VotingPhase])
+                  )
+                }
             )
         }
 
@@ -502,7 +507,7 @@ object ProtocolStateCommands extends Commands {
       phase = votingPhaseFor(state.phase).getOrElse(
         sys.error(s"No voting phase for ${state.phase}")
       )
-      qc = QuorumCertificate[TestAgreement](
+      qc = QuorumCertificate[TestAgreement, VotingPhase](
         phase,
         state.viewNumber,
         blockHash,
@@ -853,7 +858,7 @@ object ProtocolStateCommands extends Commands {
           if (state.phase == Phase.Decide) None else state.maybeBlockHash,
         prepareQCs =
           if (message.quorumCertificate.phase == Phase.Prepare)
-            message.quorumCertificate :: state.prepareQCs
+            message.quorumCertificate.coerce[Phase.Prepare] :: state.prepareQCs
           else state.prepareQCs,
         newViewsHighQC =
           if (state.phase == Phase.Decide) genesisQC else state.newViewsHighQC

--- a/metronome/hotstuff/consensus/props/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
+++ b/metronome/hotstuff/consensus/props/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolStateProps.scala
@@ -319,7 +319,7 @@ object ProtocolStateCommands extends Commands {
     ): Gen[QuorumCertificate[TestAgreement, P]] = {
       Gen.oneOf(
         genLazy(
-          qc.withBlockHash(invalidateHash(qc.blockHash))
+          qc.copy[TestAgreement, P](blockHash = invalidateHash(qc.blockHash))
         ),
         // Now that the compiler (and codecs) check that we're getting the right message,
         // we shouldn't encounter an unexpected phase in a field like `highQC`,
@@ -329,12 +329,15 @@ object ProtocolStateCommands extends Commands {
         //   qc.withPhase[VotingPhase](nextVoting(qc.votingPhase))
         // ).suchThat(_.blockHash != genesisQC.blockHash),
         genLazy(
-          qc.withViewNumber(invalidateViewNumber(qc.viewNumber))
+          qc.copy[TestAgreement, P](viewNumber =
+            invalidateViewNumber(qc.viewNumber)
+          )
         ),
         genLazy(
-          qc.withSignature(
+          qc.copy[TestAgreement, P](
             // The quorum cert has no items, so add one to make it different.
-            qc.signature.copy(sig = 0L +: qc.signature.sig.map(invalidateSig))
+            signature =
+              qc.signature.copy(sig = 0L +: qc.signature.sig.map(invalidateSig))
           )
         )
       )

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Effect.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Effect.scala
@@ -43,7 +43,7 @@ object Effect {
     */
   case class CreateBlock[A <: Agreement](
       viewNumber: ViewNumber,
-      highQC: QuorumCertificate[A]
+      highQC: QuorumCertificate[A, Phase.Prepare]
   ) extends Effect[A]
 
   /** Once the Prepare Q.C. has been established for a block,
@@ -67,7 +67,7 @@ object Effect {
     */
   case class ExecuteBlocks[A <: Agreement](
       lastExecutedBlockHash: A#Hash,
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, Phase.Commit]
   ) extends Effect[A]
 
 }

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Event.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Event.scala
@@ -21,6 +21,6 @@ object Event {
       viewNumber: ViewNumber,
       block: A#Block,
       // The certificate which the block extended.
-      highQC: QuorumCertificate[A]
+      highQC: QuorumCertificate[A, Phase.Prepare]
   ) extends Event[A]
 }

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Message.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Message.scala
@@ -24,7 +24,7 @@ object Message {
   case class Prepare[A <: Agreement](
       viewNumber: ViewNumber,
       block: A#Block,
-      highQC: QuorumCertificate[A]
+      highQC: QuorumCertificate[A, Phase.Prepare]
   ) extends LeaderMessage[A]
 
   /** Having received one of the leader messages, the replica
@@ -56,7 +56,7 @@ object Message {
     */
   case class Quorum[A <: Agreement](
       viewNumber: ViewNumber,
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, VotingPhase]
   ) extends LeaderMessage[A]
 
   /** At the end of the round, replicas send the `NewView` message
@@ -64,6 +64,6 @@ object Message {
     */
   case class NewView[A <: Agreement](
       viewNumber: ViewNumber,
-      prepareQC: QuorumCertificate[A]
+      prepareQC: QuorumCertificate[A, Phase.Prepare]
   ) extends ReplicaMessage[A]
 }

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Phase.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Phase.scala
@@ -46,4 +46,8 @@ object Phase {
   case object PreCommit extends VotingPhase
   case object Commit    extends VotingPhase
   case object Decide    extends Phase
+
+  type Prepare   = Prepare.type
+  type PreCommit = PreCommit.type
+  type Commit    = Commit.type
 }

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolError.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/ProtocolError.scala
@@ -32,7 +32,7 @@ object ProtocolError {
   /** The Q.C. signature doesn't match the content. */
   case class InvalidQuorumCertificate[A <: Agreement](
       sender: A#PKey,
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, VotingPhase]
   ) extends ProtocolError[A]
 
   /** The block in the prepare message doesn't extend the previous Q.C. */

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/QuorumCertificate.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/QuorumCertificate.scala
@@ -2,13 +2,49 @@ package io.iohk.metronome.hotstuff.consensus.basic
 
 import io.iohk.metronome.crypto.GroupSignature
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
+import scala.reflect.ClassTag
 
 /** A Quorum Certifcate (QC) over a tuple (message-type, view-number, block-hash) is a data type
   * that combines a collection of signatures for the same tuple signed by (n − f) replicas.
   */
-case class QuorumCertificate[A <: Agreement](
-    phase: VotingPhase,
+case class QuorumCertificate[A <: Agreement, +P <: VotingPhase](
+    phase: P,
     viewNumber: ViewNumber,
     blockHash: A#Hash,
     signature: GroupSignature[A#PKey, (VotingPhase, ViewNumber, A#Hash), A#GSig]
-)
+) {
+  def coerce[V <: VotingPhase](implicit
+      ct: ClassTag[V]
+  ): QuorumCertificate[A, V] = {
+    // The following assertion is not always true in testing.
+    // This is a remnant of the fact that originally the `QuorumCertificate` was not generic in P,
+    // and tests generate invalid certificates, which the code is supposed to detect.
+    // We can coerce into the wrong type, but accessing the `phase` on such an instance would lead
+    // to a `ClassCastException`. In practice the codecs will reject such messages.
+
+    // assert(ct.unapply(phase).isDefined)
+    this.asInstanceOf[QuorumCertificate[A, V]]
+  }
+
+  protected[basic] def withPhase[V <: VotingPhase](phase: V) =
+    copy[A, V](phase = phase)
+
+  protected[basic] def withViewNumber(viewNumber: ViewNumber) =
+    copy[A, P](viewNumber = viewNumber)
+
+  protected[basic] def withBlockHash(blockHash: A#Hash) =
+    copy[A, P](blockHash = blockHash)
+
+  protected[basic] def withSignature(
+      signature: GroupSignature[
+        A#PKey,
+        (VotingPhase, ViewNumber, A#Hash),
+        A#GSig
+      ]
+  ) =
+    copy[A, P](signature = signature)
+
+  // Sometimes when we have just `QuorumCertificate[A, _]` the compiler
+  // can't prove that `.phase` is a `VotingPhase` and not just `$1`.
+  protected[basic] def votingPhase: VotingPhase = phase
+}

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/QuorumCertificate.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/QuorumCertificate.scala
@@ -27,28 +27,4 @@ case class QuorumCertificate[A <: Agreement, +P <: VotingPhase](
     )
     this.asInstanceOf[QuorumCertificate[A, V]]
   }
-
-  // The following methods are used in tests.
-
-  def withPhase[V <: VotingPhase](phase: V) =
-    copy[A, V](phase = phase)
-
-  def withViewNumber(viewNumber: ViewNumber) =
-    copy[A, P](viewNumber = viewNumber)
-
-  def withBlockHash(blockHash: A#Hash) =
-    copy[A, P](blockHash = blockHash)
-
-  def withSignature(
-      signature: GroupSignature[
-        A#PKey,
-        (VotingPhase, ViewNumber, A#Hash),
-        A#GSig
-      ]
-  ) =
-    copy[A, P](signature = signature)
-
-  // Sometimes when we have just `QuorumCertificate[A, _]` the compiler
-  // can't prove that `.phase` is a `VotingPhase` and not just `$1`.
-  def votingPhase: VotingPhase = phase
 }

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Signing.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Signing.scala
@@ -50,12 +50,12 @@ trait Signing[A <: Agreement] {
 
   def validate(
       federation: Federation[A#PKey],
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, _]
   ): Boolean =
     validate(
       federation,
       quorumCertificate.signature,
-      quorumCertificate.phase,
+      quorumCertificate.votingPhase,
       quorumCertificate.viewNumber,
       quorumCertificate.blockHash
     )

--- a/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Signing.scala
+++ b/metronome/hotstuff/consensus/src/io/iohk/metronome/hotstuff/consensus/basic/Signing.scala
@@ -50,12 +50,12 @@ trait Signing[A <: Agreement] {
 
   def validate(
       federation: Federation[A#PKey],
-      quorumCertificate: QuorumCertificate[A, _]
+      quorumCertificate: QuorumCertificate[A, VotingPhase]
   ): Boolean =
     validate(
       federation,
       quorumCertificate.signature,
-      quorumCertificate.votingPhase,
+      quorumCertificate.phase,
       quorumCertificate.viewNumber,
       quorumCertificate.blockHash
     )

--- a/metronome/hotstuff/service/props/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
+++ b/metronome/hotstuff/service/props/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutorProps.scala
@@ -73,7 +73,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
     private def appService(semaphore: Semaphore[Task]) =
       new ApplicationService[Task, TestAgreement] {
         def createBlock(
-            highQC: QuorumCertificate[TestAgreement]
+            highQC: QuorumCertificate[TestAgreement, Phase.Prepare]
         ): Task[Option[TestBlock]] = ???
 
         def validateBlock(block: TestBlock): Task[Option[Boolean]] = ???
@@ -86,7 +86,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
 
         def executeBlock(
             block: TestBlock,
-            commitQC: QuorumCertificate[TestAgreement],
+            commitQC: QuorumCertificate[TestAgreement, Phase.Commit],
             commitPath: NonEmptyList[TestAgreement.Hash]
         ): Task[Boolean] =
           isExecutingRef
@@ -108,7 +108,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
       for {
         viewStateStorage <- Resource.liftF {
           storeRunner.runReadWrite {
-            val genesisQC = QuorumCertificate[TestAgreement](
+            val genesisQC = QuorumCertificate[TestAgreement, Phase.Commit](
               phase = Phase.Commit,
               viewNumber = ViewNumber(0),
               blockHash = blocks.head.id,
@@ -171,7 +171,7 @@ object BlockExecutorProps extends Properties("BlockExecutor") {
             ancestor = tree.last
             descendantTree <- genNonEmptyBlockTree(parent = ancestor)
             descendant = descendantTree.last
-            commitQC = QuorumCertificate[TestAgreement](
+            commitQC = QuorumCertificate[TestAgreement, Phase.Commit](
               phase = Phase.Commit,
               viewNumber = viewNumber,
               blockHash = descendant.id,

--- a/metronome/hotstuff/service/props/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizerProps.scala
+++ b/metronome/hotstuff/service/props/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizerProps.scala
@@ -9,7 +9,11 @@ import io.iohk.metronome.hotstuff.consensus.{
   Federation,
   LeaderSelection
 }
-import io.iohk.metronome.hotstuff.consensus.basic.{QuorumCertificate, Phase}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  QuorumCertificate,
+  Phase,
+  VotingPhase
+}
 import io.iohk.metronome.hotstuff.service.storage.BlockStorageProps
 import io.iohk.metronome.storage.InMemoryKVStore
 import org.scalacheck.{Properties, Arbitrary, Gen, Prop}, Arbitrary.arbitrary
@@ -45,7 +49,9 @@ object BlockSynchronizerProps extends Properties("BlockSynchronizer") {
   case class TestFixture(
       ancestorTree: List[TestBlock],
       descendantTree: List[TestBlock],
-      requests: List[(TestAgreement.PKey, QuorumCertificate[TestAgreement])],
+      requests: List[
+        (TestAgreement.PKey, QuorumCertificate[TestAgreement, VotingPhase])
+      ],
       federation: Federation[TestAgreement.PKey],
       random: Random,
       timeoutProb: Prob,
@@ -127,7 +133,7 @@ object BlockSynchronizerProps extends Properties("BlockSynchronizer") {
 
         requests = (prepares zip proposerKeys).zipWithIndex.map {
           case ((parent, publicKey), idx) =>
-            publicKey -> QuorumCertificate[TestAgreement](
+            publicKey -> QuorumCertificate[TestAgreement, Phase.Prepare](
               phase = Phase.Prepare,
               viewNumber = ViewNumber(100L + idx),
               blockHash = parent.id,

--- a/metronome/hotstuff/service/props/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/props/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -165,19 +165,20 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
             status.prepareQC.viewNumber.prev
           ) -> "view number less than prepare"
         ),
-        delay(
-          status.copy(prepareQC =
-            status.commitQC.coerce[Phase.Prepare]
-          ) -> "commit instead of prepare"
-        ),
+        // The following two are now prevented by the compiler and the codecs:
+        // delay(
+        //   status.copy(prepareQC =
+        //     status.commitQC.coerce[Phase.Prepare]
+        //   ) -> "commit instead of prepare"
+        // ),
+        // delay(
+        //   status.copy(commitQC =
+        //     status.prepareQC.coerce[Phase.Commit]
+        //   ) -> "prepare instead of commit"
+        // ),
         delay(
           status.copy(commitQC =
-            status.prepareQC.coerce[Phase.Commit]
-          ) -> "prepare instead of commit"
-        ),
-        delay(
-          status.copy(commitQC =
-            status.commitQC.copy[TestAgreement, Phase.Commit](signature =
+            status.commitQC.withSignature(
               status.commitQC.signature
                 .copy(sig = status.commitQC.signature.sig.map(_ * 2))
             )

--- a/metronome/hotstuff/service/props/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
+++ b/metronome/hotstuff/service/props/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizerProps.scala
@@ -178,8 +178,8 @@ object ViewSynchronizerProps extends Properties("ViewSynchronizer") {
         // ),
         delay(
           status.copy(commitQC =
-            status.commitQC.withSignature(
-              status.commitQC.signature
+            status.commitQC.copy[TestAgreement, Phase.Commit](
+              signature = status.commitQC.signature
                 .copy(sig = status.commitQC.signature.sig.map(_ * 2))
             )
           ) -> "wrong commit signature"

--- a/metronome/hotstuff/service/specs/src/io/iohk/metronome/hotstuff/service/MessageStashSpec.scala
+++ b/metronome/hotstuff/service/specs/src/io/iohk/metronome/hotstuff/service/MessageStashSpec.scala
@@ -35,7 +35,7 @@ class MessageStashSpec extends AnyFlatSpec with Matchers {
         "Alice",
         Message.NewView(
           ViewNumber(10),
-          QuorumCertificate[TestAgreement](
+          QuorumCertificate[TestAgreement, Phase.Prepare](
             Phase.Prepare,
             ViewNumber(9),
             123,
@@ -63,7 +63,7 @@ class MessageStashSpec extends AnyFlatSpec with Matchers {
         error.event.copy(message =
           Message.NewView(
             ViewNumber(10),
-            QuorumCertificate[TestAgreement](
+            QuorumCertificate[TestAgreement, Phase.Prepare](
               Phase.Prepare,
               ViewNumber(8),
               122,

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ApplicationService.scala
@@ -1,14 +1,20 @@
 package io.iohk.metronome.hotstuff.service
 
 import cats.data.{NonEmptyVector, NonEmptyList}
-import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Agreement,
+  QuorumCertificate,
+  Phase
+}
 
 /** Represents the "application" domain to the HotStuff module,
   * performing all delegations that HotStuff can't do on its own.
   */
 trait ApplicationService[F[_], A <: Agreement] {
   // TODO (PM-3109): Create block.
-  def createBlock(highQC: QuorumCertificate[A]): F[Option[A#Block]]
+  def createBlock(
+      highQC: QuorumCertificate[A, Phase.Prepare]
+  ): F[Option[A#Block]]
 
   // TODO (PM-3132, PM-3133): Block validation.
   // Returns None if validation cannot be carried out due to data availability issues within a given timeout.
@@ -24,7 +30,7 @@ trait ApplicationService[F[_], A <: Agreement] {
   // whether the block and any corresponding state can be used as a starting point after a restart.
   def executeBlock(
       block: A#Block,
-      commitQC: QuorumCertificate[A],
+      commitQC: QuorumCertificate[A, Phase.Commit],
       commitPath: NonEmptyList[A#Hash]
   ): F[Boolean]
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -338,7 +338,9 @@ class ConsensusService[
         viewStateStorage.setViewNumber(viewNumber)
       }
 
-  private def updateQuorum(quorumCertificate: QuorumCertificate[A]): F[Unit] =
+  private def updateQuorum(
+      quorumCertificate: QuorumCertificate[A, _]
+  ): F[Unit] =
     tracers.quorum(quorumCertificate) >>
       storeRunner.runReadWrite {
         viewStateStorage.setQuorumCertificate(quorumCertificate)

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/Status.scala
@@ -1,7 +1,11 @@
 package io.iohk.metronome.hotstuff.service
 
 import io.iohk.metronome.hotstuff.consensus.ViewNumber
-import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  Agreement,
+  QuorumCertificate,
+  Phase
+}
 
 /** Status has all the fields necessary for nodes to sync with each other.
   *
@@ -10,6 +14,6 @@ import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, QuorumCertificate}
   */
 case class Status[A <: Agreement](
     viewNumber: ViewNumber,
-    prepareQC: QuorumCertificate[A],
-    commitQC: QuorumCertificate[A]
+    prepareQC: QuorumCertificate[A, Phase.Prepare],
+    commitQC: QuorumCertificate[A, Phase.Commit]
 )

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/execution/BlockExecutor.scala
@@ -13,7 +13,8 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
   Block,
   Effect,
-  QuorumCertificate
+  QuorumCertificate,
+  Phase
 }
 import io.iohk.metronome.hotstuff.service.tracing.ConsensusTracers
 import io.iohk.metronome.storage.KVStoreRunner
@@ -122,7 +123,7 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement: Block](
   private def getBlockPath(
       lastExecutedBlockHash: A#Hash,
       lastCommittedBlockHash: A#Hash,
-      commitQC: QuorumCertificate[A]
+      commitQC: QuorumCertificate[A, Phase.Commit]
   ): F[List[A#Hash]] = {
     def readPath(ancestorBlockHash: A#Hash) =
       storeRunner
@@ -156,7 +157,7 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement: Block](
     */
   private def tryExecuteBatch(
       newBlockHashes: List[A#Hash],
-      commitQC: QuorumCertificate[A],
+      commitQC: QuorumCertificate[A, Phase.Commit],
       lastExecutedBlockHash: A#Hash
   ): F[Unit] = {
     def loop(
@@ -205,7 +206,7 @@ class BlockExecutor[F[_]: Sync, N, A <: Agreement: Block](
     */
   private def executeBlock(
       blockHash: A#Hash,
-      commitQC: QuorumCertificate[A],
+      commitQC: QuorumCertificate[A, Phase.Commit],
       commitPath: NonEmptyList[A#Hash],
       lastExecutedBlockHash: A#Hash
   ): F[Option[A#Hash]] = {

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
@@ -115,11 +115,8 @@ object ViewStateStorage {
       commitQC: QuorumCertificate[A, Phase.Commit],
       lastExecutedBlockHash: A#Hash,
       rootBlockHash: A#Hash
-  ) {
-    assert(prepareQC.phase == Phase.Prepare)
-    assert(lockedQC.phase == Phase.PreCommit)
-    assert(commitQC.phase == Phase.Commit)
-  }
+  )
+
   object Bundle {
 
     /** Convenience method reflecting the expectation that the signature

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/storage/ViewStateStorage.scala
@@ -5,10 +5,12 @@ import io.iohk.metronome.hotstuff.consensus.ViewNumber
 import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
   QuorumCertificate,
-  Phase
+  Phase,
+  VotingPhase
 }
 import io.iohk.metronome.storage.{KVStore, KVStoreRead}
-import scodec.{Codec, Encoder, Decoder}
+import scodec.{Codec, Encoder, Decoder, Attempt, Err}
+import scala.reflect.ClassTag
 
 class ViewStateStorage[N, A <: Agreement] private (
     namespace: N
@@ -17,7 +19,9 @@ class ViewStateStorage[N, A <: Agreement] private (
     kvn: KVStore.Ops[N],
     kvrn: KVStoreRead.Ops[N],
     codecVN: Codec[ViewNumber],
-    codecQC: Codec[QuorumCertificate[A]],
+    codecQCP: Codec[QuorumCertificate[A, Phase.Prepare]],
+    codecQCPC: Codec[QuorumCertificate[A, Phase.PreCommit]],
+    codecQCC: Codec[QuorumCertificate[A, Phase.Commit]],
     codecH: Codec[A#Hash]
 ) {
   import keys.Key
@@ -35,14 +39,14 @@ class ViewStateStorage[N, A <: Agreement] private (
   def setViewNumber(viewNumber: ViewNumber): KVStore[N, Unit] =
     put(Key.ViewNumber, viewNumber)
 
-  def setQuorumCertificate(qc: QuorumCertificate[A]): KVStore[N, Unit] =
+  def setQuorumCertificate(qc: QuorumCertificate[A, _]): KVStore[N, Unit] =
     qc.phase match {
       case Phase.Prepare =>
-        put(Key.PrepareQC, qc)
+        put(Key.PrepareQC, qc.coerce[Phase.Prepare])
       case Phase.PreCommit =>
-        put(Key.LockedQC, qc)
+        put(Key.LockedQC, qc.coerce[Phase.PreCommit])
       case Phase.Commit =>
-        put(Key.CommitQC, qc)
+        put(Key.CommitQC, qc.coerce[Phase.Commit])
     }
 
   def setLastExecutedBlockHash(blockHash: A#Hash): KVStore[N, Unit] =
@@ -87,9 +91,9 @@ object ViewStateStorage {
     sealed abstract class Key[V](private val code: Int)
     object Key {
       case object ViewNumber            extends Key[ViewNumber](0)
-      case object PrepareQC             extends Key[QuorumCertificate[A]](1)
-      case object LockedQC              extends Key[QuorumCertificate[A]](2)
-      case object CommitQC              extends Key[QuorumCertificate[A]](3)
+      case object PrepareQC             extends Key[QuorumCertificate[A, Phase.Prepare]](1)
+      case object LockedQC              extends Key[QuorumCertificate[A, Phase.PreCommit]](2)
+      case object CommitQC              extends Key[QuorumCertificate[A, Phase.Commit]](3)
       case object LastExecutedBlockHash extends Key[A#Hash](4)
       case object RootBlockHash         extends Key[A#Hash](5)
 
@@ -106,9 +110,9 @@ object ViewStateStorage {
     */
   case class Bundle[A <: Agreement](
       viewNumber: ViewNumber,
-      prepareQC: QuorumCertificate[A],
-      lockedQC: QuorumCertificate[A],
-      commitQC: QuorumCertificate[A],
+      prepareQC: QuorumCertificate[A, Phase.Prepare],
+      lockedQC: QuorumCertificate[A, Phase.PreCommit],
+      commitQC: QuorumCertificate[A, Phase.Commit],
       lastExecutedBlockHash: A#Hash,
       rootBlockHash: A#Hash
   ) {
@@ -122,16 +126,35 @@ object ViewStateStorage {
       * in the genesis Q.C. will not depend on the phase, just the genesis
       * hash.
       */
-    def fromGenesisQC[A <: Agreement](genesisQC: QuorumCertificate[A]) =
+    def fromGenesisQC[A <: Agreement](genesisQC: QuorumCertificate[A, _]) =
       Bundle[A](
         viewNumber = genesisQC.viewNumber,
-        prepareQC = genesisQC.copy[A](phase = Phase.Prepare),
-        lockedQC = genesisQC.copy[A](phase = Phase.PreCommit),
-        commitQC = genesisQC.copy[A](phase = Phase.Commit),
+        prepareQC = genesisQC.copy[A, Phase.Prepare](phase = Phase.Prepare),
+        lockedQC = genesisQC.copy[A, Phase.PreCommit](phase = Phase.PreCommit),
+        commitQC = genesisQC.copy[A, Phase.Commit](phase = Phase.Commit),
         lastExecutedBlockHash = genesisQC.blockHash,
         rootBlockHash = genesisQC.blockHash
       )
   }
+
+  private implicit def codecQCP[A <: Agreement, P <: VotingPhase](implicit
+      ev: Codec[QuorumCertificate[A, VotingPhase]],
+      ct: ClassTag[P]
+  ) = ev.exmap[QuorumCertificate[A, P]](
+    qc =>
+      ct.unapply(qc.phase)
+        .map { _ =>
+          Attempt.successful(qc.coerce[P])
+        }
+        .getOrElse {
+          Attempt.failure(
+            Err(
+              s"Invalid phase in view state storage: ${qc.phase}, expected ${ct.runtimeClass.getSimpleName}"
+            )
+          )
+        },
+    qc => Attempt.successful(qc)
+  )
 
   /** Create a ViewStateStorage instance by pre-loading it with the genesis,
     * unless it already has data.
@@ -141,7 +164,7 @@ object ViewStateStorage {
       genesis: Bundle[A]
   )(implicit
       codecVN: Codec[ViewNumber],
-      codecQC: Codec[QuorumCertificate[A]],
+      codecQC: Codec[QuorumCertificate[A, VotingPhase]],
       codecH: Codec[A#Hash]
   ): KVStore[N, ViewStateStorage[N, A]] = {
     implicit val kvn  = KVStore.instance[N]

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/BlockSynchronizer.scala
@@ -63,7 +63,7 @@ class BlockSynchronizer[F[_]: Sync: Timer, N, A <: Agreement: Block](
     */
   def sync(
       sender: A#PKey,
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, _]
   ): F[Unit] =
     for {
       path <- download(sender, quorumCertificate.blockHash, Nil)
@@ -84,7 +84,7 @@ class BlockSynchronizer[F[_]: Sync: Timer, N, A <: Agreement: Block](
     */
   def getBlockFromQuorumCertificate(
       sources: NonEmptyVector[A#PKey],
-      quorumCertificate: QuorumCertificate[A]
+      quorumCertificate: QuorumCertificate[A, _]
   ): F[Either[DownloadFailedException[A], A#Block]] = {
     val otherSources = sources.filterNot(_ == publicKey).toList
 

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
@@ -9,8 +9,7 @@ import io.iohk.metronome.hotstuff.consensus.{Federation, ViewNumber}
 import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
   Signing,
-  QuorumCertificate,
-  Phase
+  QuorumCertificate
 }
 import io.iohk.metronome.hotstuff.service.Status
 import io.iohk.metronome.hotstuff.service.tracing.SyncTracers
@@ -95,13 +94,11 @@ class ViewSynchronizer[F[_]: Sync: Timer: Parallel, A <: Agreement: Signing](
   ] =
     for {
       _ <- validateQC(from, status.prepareQC)(
-        checkPhase(Phase.Prepare),
         checkSignature,
         checkVisible(status),
         checkPrepareIsAfterCommit(status)
       )
       _ <- validateQC(from, status.commitQC)(
-        checkPhase(Phase.Commit),
         checkSignature,
         checkVisible(status)
       )
@@ -109,9 +106,6 @@ class ViewSynchronizer[F[_]: Sync: Timer: Parallel, A <: Agreement: Signing](
 
   private def check(cond: Boolean, hint: => String) =
     if (cond) none else hint.some
-
-  private def checkPhase(phase: Phase)(qc: QuorumCertificate[A, _]) =
-    check(phase == qc.phase, s"Phase should be $phase.")
 
   private def checkSignature(qc: QuorumCertificate[A, _]) =
     check(Signing[A].validate(federation, qc), "Invalid signature.")

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/sync/ViewSynchronizer.scala
@@ -107,7 +107,7 @@ class ViewSynchronizer[F[_]: Sync: Timer: Parallel, A <: Agreement: Signing](
   private def check(cond: Boolean, hint: => String) =
     if (cond) none else hint.some
 
-  private def checkSignature(qc: QuorumCertificate[A, _]) =
+  private def checkSignature(qc: QuorumCertificate[A, VotingPhase]) =
     check(Signing[A].validate(federation, qc), "Invalid signature.")
 
   private def checkVisible(status: Status[A])(qc: QuorumCertificate[A, _]) =
@@ -128,7 +128,7 @@ class ViewSynchronizer[F[_]: Sync: Timer: Parallel, A <: Agreement: Signing](
       from: A#PKey,
       qc: QuorumCertificate[A, P]
   )(
-      checks: (QuorumCertificate[A, _] => Option[String])*
+      checks: (QuorumCertificate[A, VotingPhase] => Option[String])*
   ) =
     checks.toList.traverse { check =>
       check(qc)

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusEvent.scala
@@ -6,7 +6,10 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   Event,
   ProtocolError
 }
-import io.iohk.metronome.hotstuff.consensus.basic.QuorumCertificate
+import io.iohk.metronome.hotstuff.consensus.basic.{
+  QuorumCertificate,
+  VotingPhase
+}
 import io.iohk.metronome.hotstuff.service.ConsensusService.MessageCounter
 import io.iohk.metronome.hotstuff.service.Status
 
@@ -34,8 +37,9 @@ object ConsensusEvent {
   case class NewView(viewNumber: ViewNumber) extends ConsensusEvent[Nothing]
 
   /** Quorum over some block. */
-  case class Quorum[A <: Agreement](quorumCertificate: QuorumCertificate[A])
-      extends ConsensusEvent[A]
+  case class Quorum[A <: Agreement](
+      quorumCertificate: QuorumCertificate[A, VotingPhase]
+  ) extends ConsensusEvent[A]
 
   /** A formally valid message was received from an earlier view number. */
   case class FromPast[A <: Agreement](message: Event.MessageReceived[A])

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusTracers.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/ConsensusTracers.scala
@@ -7,7 +7,8 @@ import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
   Event,
   ProtocolError,
-  QuorumCertificate
+  QuorumCertificate,
+  VotingPhase
 }
 import io.iohk.metronome.hotstuff.service.ConsensusService.MessageCounter
 import io.iohk.metronome.hotstuff.service.Status
@@ -17,7 +18,7 @@ case class ConsensusTracers[F[_], A <: Agreement](
     viewSync: Tracer[F, ViewNumber],
     adoptView: Tracer[F, Status[A]],
     newView: Tracer[F, ViewNumber],
-    quorum: Tracer[F, QuorumCertificate[A]],
+    quorum: Tracer[F, QuorumCertificate[A, _]],
     fromPast: Tracer[F, Event.MessageReceived[A]],
     fromFuture: Tracer[F, Event.MessageReceived[A]],
     stashed: Tracer[F, ProtocolError.TooEarly[A]],
@@ -40,7 +41,9 @@ object ConsensusTracers {
       viewSync = tracer.contramap[ViewNumber](ViewSync(_)),
       adoptView = tracer.contramap[Status[A]](AdoptView(_)),
       newView = tracer.contramap[ViewNumber](NewView(_)),
-      quorum = tracer.contramap[QuorumCertificate[A]](Quorum(_)),
+      quorum = tracer.contramap[QuorumCertificate[A, _]](qc =>
+        Quorum(qc.coerce[VotingPhase])
+      ),
       fromPast = tracer.contramap[Event.MessageReceived[A]](FromPast(_)),
       fromFuture = tracer.contramap[Event.MessageReceived[A]](FromFuture(_)),
       stashed = tracer.contramap[ProtocolError.TooEarly[A]](Stashed(_)),

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/tracing/SyncEvent.scala
@@ -4,7 +4,6 @@ import io.iohk.metronome.core.Validated
 import io.iohk.metronome.hotstuff.consensus.basic.{Agreement, ProtocolError}
 import io.iohk.metronome.hotstuff.service.messages.SyncMessage
 import io.iohk.metronome.hotstuff.service.Status
-import io.iohk.metronome.hotstuff.consensus.basic.ProtocolError
 
 sealed trait SyncEvent[+A <: Agreement]
 


### PR DESCRIPTION
The result of a PR discussion, positing whether we should have separate QuorumCertificate types for each phase, to get compile time assurance where possible that the right kind are passed around, rather than just rely on assertions.

Tested with the robot integration tests which exercise the database and the network codecs as well.

Removed existing assertions and checks that can now be expected to be validated by the compiler, as well as tests that generated now illegal states.