### PR TITLE
PM-3146: Move Network to networking.

### DIFF
--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/ConsensusService.scala
@@ -24,7 +24,7 @@ import io.iohk.metronome.hotstuff.service.storage.{
   ViewStateStorage
 }
 import io.iohk.metronome.hotstuff.service.tracing.ConsensusTracers
-import io.iohk.metronome.networking.ConnectionHandler
+import io.iohk.metronome.networking.{ConnectionHandler, Network}
 import io.iohk.metronome.storage.KVStoreRunner
 import monix.catnap.ConcurrentQueue
 import scala.annotation.tailrec
@@ -41,7 +41,7 @@ class ConsensusService[
     A <: Agreement: Block: Signing
 ](
     publicKey: A#PKey,
-    network: Network[F, A, Message[A]],
+    network: Network[F, A#PKey, Message[A]],
     appService: ApplicationService[F, A],
     blockStorage: BlockStorage[N, A],
     viewStateStorage: ViewStateStorage[N, A],
@@ -545,7 +545,7 @@ object ConsensusService {
       A <: Agreement: Block: Signing
   ](
       publicKey: A#PKey,
-      network: Network[F, A, Message[A]],
+      network: Network[F, A#PKey, Message[A]],
       appService: ApplicationService[F, A],
       blockStorage: BlockStorage[N, A],
       viewStateStorage: ViewStateStorage[N, A],
@@ -585,7 +585,7 @@ object ConsensusService {
       A <: Agreement: Block: Signing
   ](
       publicKey: A#PKey,
-      network: Network[F, A, Message[A]],
+      network: Network[F, A#PKey, Message[A]],
       appService: ApplicationService[F, A],
       blockStorage: BlockStorage[N, A],
       viewStateStorage: ViewStateStorage[N, A],

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/HotStuffService.scala
@@ -22,6 +22,7 @@ import io.iohk.metronome.hotstuff.service.tracing.{
   ConsensusTracers,
   SyncTracers
 }
+import io.iohk.metronome.networking.Network
 import io.iohk.metronome.storage.KVStoreRunner
 
 object HotStuffService {
@@ -32,7 +33,7 @@ object HotStuffService {
       N,
       A <: Agreement: Block: Signing
   ](
-      network: Network[F, A, HotStuffMessage[A]],
+      network: Network[F, A#PKey, HotStuffMessage[A]],
       appService: ApplicationService[F, A],
       blockStorage: BlockStorage[N, A],
       viewStateStorage: ViewStateStorage[N, A],
@@ -44,7 +45,7 @@ object HotStuffService {
   ): Resource[F, Unit] =
     for {
       (consensusNetwork, syncNetwork) <- Network
-        .splitter[F, A, HotStuffMessage[A], Message[A], SyncMessage[A]](
+        .splitter[F, A#PKey, HotStuffMessage[A], Message[A], SyncMessage[A]](
           network
         )(
           split = {

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -27,7 +27,7 @@ import io.iohk.metronome.hotstuff.service.sync.{
   ViewSynchronizer
 }
 import io.iohk.metronome.hotstuff.service.tracing.SyncTracers
-import io.iohk.metronome.networking.ConnectionHandler
+import io.iohk.metronome.networking.{ConnectionHandler, Network}
 import io.iohk.metronome.storage.{KVStoreRunner, KVStore}
 import scala.util.control.NonFatal
 import scala.concurrent.duration._
@@ -45,7 +45,7 @@ import scala.reflect.ClassTag
   */
 class SyncService[F[_]: Concurrent: ContextShift, N, A <: Agreement: Block](
     publicKey: A#PKey,
-    network: Network[F, A, SyncMessage[A]],
+    network: Network[F, A#PKey, SyncMessage[A]],
     appService: ApplicationService[F, A],
     blockStorage: BlockStorage[N, A],
     viewStateStorage: ViewStateStorage[N, A],
@@ -355,7 +355,7 @@ object SyncService {
   ](
       publicKey: A#PKey,
       federation: Federation[A#PKey],
-      network: Network[F, A, SyncMessage[A]],
+      network: Network[F, A#PKey, SyncMessage[A]],
       appService: ApplicationService[F, A],
       blockStorage: BlockStorage[N, A],
       viewStateStorage: ViewStateStorage[N, A],


### PR DESCRIPTION
Just moves the `Network` trait to `networking` and makes it more generic, decoupled from `Agreement`.