### PR TITLE
PM-3092: Connection conflict resolution based on ephemeral port ordering

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -23,7 +23,7 @@ object VersionOf {
   val rocksdb              = "6.15.2"
   val scalacheck           = "1.15.2"
   val scalatest            = "3.2.5"
-  val scalanet             = "0.7.0"
+  val scalanet             = "0.8.0"
   val shapeless            = "2.3.3"
   val slf4j                = "1.7.30"
   val `scodec-core`        = "1.11.7"

--- a/metronome/networking/src/io/iohk/metronome/networking/EncryptedConnectionProvider.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/EncryptedConnectionProvider.scala
@@ -8,6 +8,7 @@ import io.iohk.metronome.networking.EncryptedConnectionProvider.{
 import java.net.InetSocketAddress
 
 trait EncryptedConnection[F[_], K, M] {
+  def localAddress: InetSocketAddress
   def remotePeerInfo: (K, InetSocketAddress)
   def sendMessage(m: M): F[Unit]
   def incomingMessage: F[Option[Either[ConnectionError, M]]]

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkEvent.scala
@@ -6,20 +6,27 @@ import java.net.InetSocketAddress
 sealed trait NetworkEvent[K, +M]
 
 object NetworkEvent {
+  import ConnectionHandler.HandledConnection.HandledConnectionDirection
 
   case class Peer[K](key: K, address: InetSocketAddress)
 
   /** The connection to/from the peer has been added to the register. */
-  case class ConnectionRegistered[K](peer: Peer[K])
-      extends NetworkEvent[K, Nothing]
+  case class ConnectionRegistered[K](
+      peer: Peer[K],
+      direction: HandledConnectionDirection
+  ) extends NetworkEvent[K, Nothing]
 
   /** The connection to/from the peer has been closed and removed from the register. */
-  case class ConnectionDeregistered[K](peer: Peer[K])
-      extends NetworkEvent[K, Nothing]
+  case class ConnectionDeregistered[K](
+      peer: Peer[K],
+      direction: HandledConnectionDirection
+  ) extends NetworkEvent[K, Nothing]
 
   /** We had two connections to/from the peer and discarded one of them. */
-  case class ConnectionDiscarded[K](peer: Peer[K])
-      extends NetworkEvent[K, Nothing]
+  case class ConnectionDiscarded[K](
+      peer: Peer[K],
+      direction: HandledConnectionDirection
+  ) extends NetworkEvent[K, Nothing]
 
   /** Failed to establish connection to remote peer. */
   case class ConnectionFailed[K](

--- a/metronome/networking/src/io/iohk/metronome/networking/NetworkTracers.scala
+++ b/metronome/networking/src/io/iohk/metronome/networking/NetworkTracers.scala
@@ -36,13 +36,22 @@ object NetworkTracers {
         ConnectionUnknown((Peer.apply[K] _).tupled(conn.remotePeerInfo))
       },
       registered = tracer.contramap[HandledConnection[F, K, M]] { conn =>
-        ConnectionRegistered(Peer(conn.key, conn.serverAddress))
+        ConnectionRegistered(
+          Peer(conn.key, conn.serverAddress),
+          conn.connectionDirection
+        )
       },
       deregistered = tracer.contramap[HandledConnection[F, K, M]] { conn =>
-        ConnectionDeregistered(Peer(conn.key, conn.serverAddress))
+        ConnectionDeregistered(
+          Peer(conn.key, conn.serverAddress),
+          conn.connectionDirection
+        )
       },
       discarded = tracer.contramap[HandledConnection[F, K, M]] { conn =>
-        ConnectionDiscarded(Peer(conn.key, conn.serverAddress))
+        ConnectionDiscarded(
+          Peer(conn.key, conn.serverAddress),
+          conn.connectionDirection
+        )
       },
       failed =
         tracer.contramap[RemoteConnectionManager.ConnectionFailure[K]] { fail =>

--- a/metronome/networking/test/src/io/iohk/metronome/networking/ConnectionHandlerSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/ConnectionHandlerSpec.scala
@@ -316,7 +316,10 @@ object ConnectionHandlerSpec {
       cb: FinishedConnection[ECPublicKey] => Task[Unit] = _ => Task(())
   ): Resource[Task, ConnectionHandler[Task, ECPublicKey, TestMessage]] = {
     ConnectionHandler
-      .apply[Task, ECPublicKey, TestMessage](cb)
+      .apply[Task, ECPublicKey, TestMessage](
+        cb,
+        oppositeConnectionOverlap = Duration.Zero
+      )
   }
 
   def buildHandlerResourceWithCallbackCounter: Resource[

--- a/metronome/networking/test/src/io/iohk/metronome/networking/MockEncryptedConnectionProvider.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/MockEncryptedConnectionProvider.scala
@@ -196,7 +196,8 @@ object MockEncryptedConnectionProvider {
       private val closeToken: TryableDeferred[Task, Unit],
       private val sentMessages: Ref[Task, List[TestMessage]],
       val remotePeerInfo: (ECPublicKey, InetSocketAddress) =
-        (getFakeRandomKey(), fakeLocalAddress)
+        (getFakeRandomKey(), fakeLocalAddress),
+      val localAddress: InetSocketAddress = fakeLocalAddress
   ) extends EncryptedConnection[Task, ECPublicKey, TestMessage] {
 
     override def close: Task[Unit] = {

--- a/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithMockProviderSpec.scala
+++ b/metronome/networking/test/src/io/iohk/metronome/networking/RemoteConnectionManagerWithMockProviderSpec.scala
@@ -298,9 +298,9 @@ object RemoteConnectionManagerWithMockProviderSpec {
 
   val noJitterConfig = RandomJitterConfig.buildJitterConfig(0).get
   val quickRetryConfig =
-    RetryConfig(50.milliseconds, 2, 2.seconds, noJitterConfig)
+    RetryConfig(50.milliseconds, 2, 2.seconds, noJitterConfig, Duration.Zero)
   val longRetryConfig: RetryConfig =
-    RetryConfig(5.seconds, 2, 20.seconds, noJitterConfig)
+    RetryConfig(5.seconds, 2, 20.seconds, noJitterConfig, Duration.Zero)
 
   def buildTestCaseWithNPeers(
       n: Int,


### PR DESCRIPTION
The integration tests of https://github.com/input-output-hk/metronome/pull/51 failed with often with this kind of network log:

```
localhost/127.0.0.1:34953 - 2021-06-04T16:43:30.044162Z: ConnectionRegistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x697fa1a96f44dd9e...)),localhost/127.0.0.1:37597))
localhost/127.0.0.1:37597 - 2021-06-04T16:43:30.050472Z: ConnectionRegistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x7c308620b5c8d000...)),localhost/127.0.0.1:34953))
localhost/127.0.0.1:37597 - 2021-06-04T16:43:30.082489Z: ConnectionDiscarded(Peer(ECPublicKey(ByteVector(64 bytes, 0x7c308620b5c8d000f...)),localhost/127.0.0.1:34953))
localhost/127.0.0.1:37597 - 2021-06-04T16:43:30.127455Z: ConnectionDeregistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x7c308620b5c8d0...)),localhost/127.0.0.1:34953))
localhost/127.0.0.1:34953 - 2021-06-04T16:43:30.139837Z: ConnectionRegistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x697fa1a96f44dd9e...)),localhost/127.0.0.1:37597))
localhost/127.0.0.1:34953 - 2021-06-04T16:43:30.145508Z: ConnectionDeregistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x697fa1a96f44dd...)),localhost/127.0.0.1:37597))
localhost/127.0.0.1:34953 - 2021-06-04T16:43:31.183316Z: ConnectionRegistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x697fa1a96f44dd9e...)),localhost/127.0.0.1:37597))
localhost/127.0.0.1:37597 - 2021-06-04T16:43:31.189024Z: ConnectionRegistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x7c308620b5c8d000...)),localhost/127.0.0.1:34953))
localhost/127.0.0.1:37597 - 2021-06-04T16:43:31.281460Z: ConnectionDiscarded(Peer(ECPublicKey(ByteVector(64 bytes, 0x7c308620b5c8d000f...)),localhost/127.0.0.1:34953))
localhost/127.0.0.1:37597 - 2021-06-04T16:43:31.292620Z: ConnectionDeregistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x7c308620b5c8d0...)),localhost/127.0.0.1:34953))
localhost/127.0.0.1:34953 - 2021-06-04T16:43:31.297326Z: ConnectionRegistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x697fa1a96f44dd9e...)),localhost/127.0.0.1:37597))
localhost/127.0.0.1:34953 - 2021-06-04T16:43:31.300318Z: ConnectionDeregistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x697fa1a96f44dd...)),localhost/127.0.0.1:37597))
localhost/127.0.0.1:37597 - 2021-06-04T16:43:31.301845Z: ConnectionSendError(Peer(ECPublicKey(ByteVector(64 bytes, 0x7c308620b5c8d000f...)),localhost/127.0.0.1:34953))
localhost/127.0.0.1:37597 - 2021-06-04T16:43:32.418044Z: ConnectionRegistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x7c308620b5c8d000...)),localhost/127.0.0.1:34953))
localhost/127.0.0.1:34953 - 2021-06-04T16:43:32.421764Z: ConnectionRegistered(Peer(ECPublicKey(ByteVector(64 bytes, 0x697fa1a96f44dd9e...)),localhost/127.0.0.1:37597))
localhost/127.0.0.1:34953 - 2021-06-04T16:43:32.451721Z: ConnectionDiscarded(Peer(ECPublicKey(ByteVector(64 bytes, 0x697fa1a96f44dd9ef...)),localhost/127.0.0.1:37597))
```

The reason was that both sides opened connections to each other like this (port values fictional):
```
                       Service           Interpreter
------------------------------           ------------------------------
  server listener port - 9871:<-\    /-> :9872 - server listener port
                             |   \  /    |
                             |    \/     |
                             |    /\     |
                             |   /  \    |
ephemeral client port - 54321:--/    \-- :65432 - ephemeral client port
------------------------------           ------------------------------
```
On each side there were two connections: one incoming and one outgoing. Both sides got their outgoing connection registered first, then they had to deal with the incoming one, which was a duplicate connection _from_ the same peer public key they already had a connection _to_. Their conflict resolution logic was symmetrical, so they both chose the same victim, say, their respective outgoing connections, which resulted in both connections being closed, since both were the outgoing connection of somebody. 

The PR adds an additional mechanism based on https://github.com/input-output-hk/scalanet/pull/134, which is that if the connection has only been opened recently, we assume that's short enough time that the reason we see a duplicate is not because the other side is trying to reconnect after the one we have in our registry has failed, but because we opened opposite directions at the same time; in this case both sides use an ordering of connections that gives the same result on each node, based on the ephemeral port used by the other side to initiate the connection from. 

There are no tests in this one, I used the integration tests in the other PR as an acceptance criteria.