### PR TITLE
FIX: Add ConfigDecoders.booleanDecoder 

### DIFF
--- a/metronome/config/src/io/iohk/metronome/config/ConfigDecoders.scala
+++ b/metronome/config/src/io/iohk/metronome/config/ConfigDecoders.scala
@@ -22,9 +22,17 @@ object ConfigDecoders {
     }
 
   /** Parse HOCON durations like "5m". */
-  val durationDecoder: Decoder[FiniteDuration] =
+  implicit lazy val durationDecoder: Decoder[FiniteDuration] =
     Decoder[String].emapTry {
       tryParse(_, _.getDuration(_).toMillis.millis)
+    }
+
+  /** Overriding boolean values with system properties turns them into String,
+    * which the default circe decoder does not expect.
+    */
+  implicit lazy val booleanDecoder: Decoder[Boolean] =
+    Decoder.decodeBoolean or Decoder[String].emapTry {
+      tryParse(_, _ getBoolean _)
     }
 
   /** Parse an object where a discriminant tells us which other key value

--- a/metronome/config/test/resources/complex.conf
+++ b/metronome/config/test/resources/complex.conf
@@ -8,6 +8,7 @@ metronome {
     ],
     timeout = 5s
     max-packet-size = 512kB
+    max-incoming-connections = 10
     client-id = null
   }
   blockchain {


### PR DESCRIPTION
Overrides from `-D` system properties turned Boolean values into String.

Thanks to @biandratti for noticing and the fix.