### PR TITLE
PM-3135: Implement state synchronization in the CheckpointingService

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -160,8 +160,8 @@ class MetronomeModule(val crossScalaVersion: String) extends CrossScalaModule {
       )
 
       def single(args: String*) = T.command {
-        // ScalaCheck test
-        super.runMain(args.head, args.tail: _*)
+        // ScalaCheck test. Increased verbosity for longer stack traces.
+        super.runMain(args.head, (args.tail ++ Seq("-verbosity", "3")): _*)
       }
     }
   }

--- a/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/BlockCreationProps.scala
+++ b/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/BlockCreationProps.scala
@@ -81,10 +81,9 @@ object BlockCreationProps extends Properties("BlockCreation") {
         createdBody <- arbitrary[Option[Block.Body]]
 
         hasCheckpointCandidate = createdBody
-          .map(_.transactions.collect {
+          .exists(_.transactions.collect {
             case _: Transaction.CheckpointCandidate =>
           }.nonEmpty)
-          .getOrElse(false)
 
         initialMempool <- arbitrary[Mempool].map(
           _.copy(hasNewCheckpointCandidate = hasCheckpointCandidate).add(

--- a/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
+++ b/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
@@ -40,6 +40,8 @@ import org.scalacheck.{Gen, Prop}
 
 import scala.concurrent.duration.DurationInt
 import cats.data.NonEmptyVector
+import io.iohk.metronome.tracer.Tracer
+import io.iohk.metronome.checkpointing.service.tracing.CheckpointingEvent
 
 object CheckpointingServiceFixtures {
 
@@ -125,6 +127,8 @@ object CheckpointingServiceFixtures {
               stateHash: Ledger.Hash
           ): Task[Either[Throwable, Boolean]] = ???
         }
+
+      implicit val tracer = Tracer.noOpTracer[Task, CheckpointingEvent]
 
       interpreterClientResource.flatMap { interpreterClient =>
         Resource.liftF {

--- a/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
+++ b/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
@@ -103,7 +103,8 @@ object CheckpointingServiceFixtures {
 
     def config: CheckpointingService.Config = CheckpointingService.Config(
       expectCheckpointCandidateNotifications = true,
-      interpreterTimeout = 10.seconds
+      interpreterTimeout = 10.seconds,
+      networkTimeout = 5.seconds
     )
 
     type InterpreterClient <: InterpreterRPC[Task]

--- a/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
+++ b/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
@@ -3,6 +3,7 @@ package io.iohk.metronome.checkpointing.service
 import cats.effect.Resource
 import cats.effect.concurrent.Ref
 import cats.implicits._
+import io.iohk.metronome.crypto.ECPublicKey
 import io.iohk.metronome.checkpointing.CheckpointingAgreement
 import io.iohk.metronome.checkpointing.interpreter.InterpreterRPC
 import io.iohk.metronome.checkpointing.models.ArbitraryInstances._
@@ -38,6 +39,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Gen, Prop}
 
 import scala.concurrent.duration.DurationInt
+import cats.data.NonEmptyVector
 
 object CheckpointingServiceFixtures {
 
@@ -116,6 +118,14 @@ object CheckpointingServiceFixtures {
       val storages = new Storages
       import storages._
 
+      val mockStateSynchronizer =
+        new CheckpointingService.StateSynchronizer[Task] {
+          override def trySyncState(
+              sources: NonEmptyVector[ECPublicKey],
+              stateHash: Ledger.Hash
+          ): Task[Either[Throwable, Boolean]] = ???
+        }
+
       interpreterClientResource.flatMap { interpreterClient =>
         Resource.liftF {
           for {
@@ -139,6 +149,7 @@ object CheckpointingServiceFixtures {
               ledgerStorage,
               blockStorage,
               interpreterClient,
+              mockStateSynchronizer,
               config
             )
 

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
@@ -352,7 +352,7 @@ object CheckpointingService {
   )(implicit
       storeRunner: KVStoreRunner[F, N],
       tracer: Tracer[F, CheckpointingEvent]
-  ) extends RPCSupport.Remote[
+  ) extends RPCSupport[
         F,
         CheckpointingAgreement.PKey,
         CheckpointingMessage,

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/InterpreterClient.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/InterpreterClient.scala
@@ -2,7 +2,7 @@ package io.iohk.metronome.checkpointing.service
 
 import cats.implicits._
 import cats.effect.{Concurrent, Timer, Resource, Sync}
-import io.iohk.metronome.core.messages.{RPCTracker, RPCPair}
+import io.iohk.metronome.core.messages.{RPCTracker, RPCSupport}
 import io.iohk.metronome.checkpointing.interpreter.messages.InterpreterMessage
 import io.iohk.metronome.checkpointing.interpreter.{ServiceRPC, InterpreterRPC}
 import io.iohk.metronome.checkpointing.interpreter.InterpreterService.InterpreterConnection
@@ -15,7 +15,6 @@ import io.iohk.metronome.checkpointing.models.{
 import io.iohk.metronome.checkpointing.service.tracing.CheckpointingEvent
 import io.iohk.metronome.tracer.Tracer
 import scala.concurrent.duration.FiniteDuration
-import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 /** Mirroring the `InterpreterService`, the `InterpreterClient` presents
@@ -30,27 +29,36 @@ object InterpreterClient {
       serviceRpc: ServiceRPC[F],
       rpcTracker: RPCTracker[F, InterpreterMessage]
   )(implicit tracer: Tracer[F, CheckpointingEvent])
-      extends InterpreterRPC[F] {
+      extends RPCSupport.Local[
+        F,
+        InterpreterMessage,
+        InterpreterMessage with Request with FromService,
+        InterpreterMessage with Response with FromInterpreter
+      ](rpcTracker, InterpreterMessage.RequestId[F])
+      with InterpreterRPC[F] {
+
+    protected override val sendRequest =
+      req => sendMessage(req)
+    protected override val requestTimeout =
+      req => tracer(InterpreterTimeout(req))
+    protected override val responseIgnored =
+      (req, err) => tracer(InterpreterResponseIgnored(req, err))
 
     override def createBlockBody(
         ledger: Ledger,
         mempool: Seq[Transaction.ProposerBlock]
     ): F[Option[Block.Body]] =
-      for {
-        requestId <- RequestId[F]
-        request = CreateBlockBodyRequest(requestId, ledger, mempool)
-        maybeResponse <- sendRequest(request)
-      } yield maybeResponse.map(_.blockBody)
+      sendRequest(CreateBlockBodyRequest(_, ledger, mempool)).map {
+        _.map(_.blockBody)
+      }
 
     override def validateBlockBody(
         blockBody: Block.Body,
         ledger: Ledger
     ): F[Option[Boolean]] =
-      for {
-        requestId <- RequestId[F]
-        request = ValidateBlockBodyRequest(requestId, blockBody, ledger)
-        maybeResponse <- sendRequest(request)
-      } yield maybeResponse.map(_.isValid)
+      sendRequest(ValidateBlockBodyRequest(_, blockBody, ledger)).map {
+        _.map(_.isValid)
+      }
 
     override def newCheckpointCertificate(
         checkpointCertificate: CheckpointCertificate
@@ -63,19 +71,6 @@ object InterpreterClient {
         )
         _ <- sendCommand(request)
       } yield ()
-
-    private def sendRequest[
-        Req <: InterpreterMessage with Request with FromService,
-        Res <: InterpreterMessage with Response with FromInterpreter
-    ](
-        request: Req
-    )(implicit ev: RPCPair.Aux[Req, Res], ct: ClassTag[Res]): F[Option[Res]] =
-      for {
-        join <- rpcTracker.register[Req, Res](request)
-        _    <- sendMessage(request)
-        res  <- join
-        _    <- tracer(InterpreterTimeout(request)).whenA(res.isEmpty)
-      } yield res
 
     private def sendCommand(
         command: InterpreterMessage
@@ -104,12 +99,7 @@ object InterpreterClient {
             tracer(Error(err))
 
           case response: Response with FromInterpreter =>
-            rpcTracker.complete(response).flatMap {
-              case Right(ok) =>
-                tracer(InterpreterResponseIgnored(response, None)).whenA(!ok)
-              case Left(ex) =>
-                tracer(InterpreterResponseIgnored(response, Some(ex)))
-            }
+            receiveResponse(response)
 
           case NewProposerBlockRequest(_, proposerBlock) =>
             serviceRpc.newProposerBlock(proposerBlock).handleErrorWith {

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/messages/CheckpointingMessage.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/messages/CheckpointingMessage.scala
@@ -28,4 +28,7 @@ object CheckpointingMessage extends RPCMessageCompanion {
       state: Ledger
   ) extends CheckpointingMessage
       with Response
+
+  implicit val getStatePair =
+    pair[GetStateRequest, GetStateResponse]
 }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/tracing/CheckpointingEvent.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/tracing/CheckpointingEvent.scala
@@ -1,6 +1,8 @@
 package io.iohk.metronome.checkpointing.service.tracing
 
+import io.iohk.metronome.checkpointing.CheckpointingAgreement
 import io.iohk.metronome.checkpointing.interpreter.messages.InterpreterMessage
+import io.iohk.metronome.checkpointing.service.messages.CheckpointingMessage
 
 sealed trait CheckpointingEvent
 
@@ -20,6 +22,19 @@ object CheckpointingEvent {
   /** The Interpreter sent us a response which we ignored, most likely because it was late. */
   case class InterpreterResponseIgnored(
       message: InterpreterMessage with Response with FromInterpreter,
+      maybeError: Option[Throwable]
+  ) extends CheckpointingEvent
+
+  /** A peer did not produce a response in time. */
+  case class NetworkTimeout(
+      recipient: CheckpointingAgreement.PKey,
+      message: CheckpointingMessage with CheckpointingMessage.Request
+  ) extends CheckpointingEvent
+
+  /** A peer sent an unsolicited response, or the response arrived too late. */
+  case class NetworkResponseIgnored(
+      from: CheckpointingAgreement.PKey,
+      message: CheckpointingMessage with CheckpointingMessage.Response,
       maybeError: Option[Throwable]
   ) extends CheckpointingEvent
 

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/tracing/CheckpointingEvent.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/tracing/CheckpointingEvent.scala
@@ -3,6 +3,8 @@ package io.iohk.metronome.checkpointing.service.tracing
 import io.iohk.metronome.checkpointing.CheckpointingAgreement
 import io.iohk.metronome.checkpointing.interpreter.messages.InterpreterMessage
 import io.iohk.metronome.checkpointing.service.messages.CheckpointingMessage
+import io.iohk.metronome.checkpointing.models.{Block, Ledger}
+import io.iohk.metronome.checkpointing.models.CheckpointCertificate
 
 sealed trait CheckpointingEvent
 
@@ -37,6 +39,25 @@ object CheckpointingEvent {
       message: CheckpointingMessage with CheckpointingMessage.Response,
       maybeError: Option[Throwable]
   ) extends CheckpointingEvent
+
+  /** This node has created a block, to be proposed to the federation. */
+  case class Proposing(
+      block: Block
+  ) extends CheckpointingEvent
+
+  /** The federation committed to a new state. */
+  case class NewState(state: Ledger) extends CheckpointingEvent
+
+  /** Pushing a new certificate to the interpreter. */
+  case class NewCheckpointCertificate(certificate: CheckpointCertificate)
+      extends CheckpointingEvent
+
+  /** A block could not be validated because we could not produce the corresponding state. */
+  case class StateUnavailable(block: Block) extends CheckpointingEvent
+
+  /** The interpreter thought the block was invalid. */
+  case class InterpreterValidationFailed(block: Block)
+      extends CheckpointingEvent
 
   /** An unexpected error. */
   case class Error(error: Throwable) extends CheckpointingEvent

--- a/metronome/core/src/io/iohk/metronome/core/messages/RPCSupport.scala
+++ b/metronome/core/src/io/iohk/metronome/core/messages/RPCSupport.scala
@@ -4,107 +4,57 @@ import cats.implicits._
 import cats.effect.Sync
 import scala.reflect.ClassTag
 
-/** Utility base classes to capture the pattern of interaction with `RPCTracker`.
+/** Utility base class to capture the pattern of interaction with `RPCTracker`.
   * It provides send and receive methods for requests and responses.
   */
-object RPCSupport {
-  abstract class Remote[
-      F[_]: Sync,
-      K,
-      M,
-      Request <: RPCMessageCompanion#Request,
-      Response <: RPCMessageCompanion#Response
-  ](
-      rpcTracker: RPCTracker[F, M],
-      requestId: F[RPCMessageCompanion#RequestId]
-  )(implicit ev1: Request <:< M, ev2: Response <:< M) {
+abstract class RPCSupport[
+    F[_]: Sync,
+    K,
+    M,
+    Request <: RPCMessageCompanion#Request,
+    Response <: RPCMessageCompanion#Response
+](
+    rpcTracker: RPCTracker[F, M],
+    requestId: F[RPCMessageCompanion#RequestId]
+)(implicit ev1: Request <:< M, ev2: Response <:< M) {
 
-    protected def sendRequest: (K, Request) => F[Unit]
+  protected def sendRequest: (K, Request) => F[Unit]
 
-    protected val requestTimeout: (K, Request) => F[Unit] =
-      (_, _) => ().pure[F]
-    protected val responseIgnored: (K, Response, Option[Throwable]) => F[Unit] =
-      (_, _, _) => ().pure[F]
+  protected val requestTimeout: (K, Request) => F[Unit] =
+    (_, _) => ().pure[F]
 
-    /** Send a request to the peer and track the response.
-      *
-      * Returns `None` if we're not connected or the request times out.
-      */
-    protected def sendRequest[Req <: Request, Res <: Response](
-        to: K,
-        mkRequest: RPCMessageCompanion#RequestId => Req
-    )(implicit
-        ev: RPCPair.Aux[Req, Res],
-        ct: ClassTag[Res]
-    ): F[Option[Res]] =
-      for {
-        requestId <- requestId
-        request = mkRequest(requestId)
-        join     <- rpcTracker.register[Req, Res](request)
-        _        <- sendRequest(to, request)
-        maybeRes <- join
-        _        <- requestTimeout(to, request).whenA(maybeRes.isEmpty)
-      } yield maybeRes
+  protected val responseIgnored: (K, Response, Option[Throwable]) => F[Unit] =
+    (_, _, _) => ().pure[F]
 
-    /** Try to complete a request when the response arrives. */
-    protected def receiveResponse[Res <: Response](
-        from: K,
-        response: Res
-    ): F[Unit] =
-      rpcTracker.complete(response).flatMap {
-        case Right(ok) =>
-          responseIgnored(from, response, None).whenA(!ok)
-        case Left(ex) =>
-          responseIgnored(from, response, Some(ex))
-      }
-  }
+  /** Send a request to the peer and track the response.
+    *
+    * Returns `None` if we're not connected or the request times out.
+    */
+  protected def sendRequest[Req <: Request, Res <: Response](
+      to: K,
+      mkRequest: RPCMessageCompanion#RequestId => Req
+  )(implicit
+      ev: RPCPair.Aux[Req, Res],
+      ct: ClassTag[Res]
+  ): F[Option[Res]] =
+    for {
+      requestId <- requestId
+      request = mkRequest(requestId)
+      join     <- rpcTracker.register[Req, Res](request)
+      _        <- sendRequest(to, request)
+      maybeRes <- join
+      _        <- requestTimeout(to, request).whenA(maybeRes.isEmpty)
+    } yield maybeRes
 
-  /** Identical to `RPCSupport.Remote` in functionality but without support for remote address. */
-  abstract class Local[
-      F[_]: Sync,
-      M,
-      Request <: RPCMessageCompanion#Request,
-      Response <: RPCMessageCompanion#Response
-  ](
-      rpcTracker: RPCTracker[F, M],
-      requestId: F[RPCMessageCompanion#RequestId]
-  )(implicit ev1: Request <:< M, ev2: Response <:< M) {
-
-    protected def sendRequest: Request => F[Unit]
-
-    protected val requestTimeout: Request => F[Unit] =
-      _ => ().pure[F]
-    protected val responseIgnored: (Response, Option[Throwable]) => F[Unit] =
-      (_, _) => ().pure[F]
-
-    /** Send a request and track the response.
-      *
-      * Returns `None` if we're not connected or the request times out.
-      */
-    protected def sendRequest[Req <: Request, Res <: Response](
-        mkRequest: RPCMessageCompanion#RequestId => Req
-    )(implicit
-        ev: RPCPair.Aux[Req, Res],
-        ct: ClassTag[Res]
-    ): F[Option[Res]] =
-      for {
-        requestId <- requestId
-        request = mkRequest(requestId)
-        join     <- rpcTracker.register[Req, Res](request)
-        _        <- sendRequest(request)
-        maybeRes <- join
-        _        <- requestTimeout(request).whenA(maybeRes.isEmpty)
-      } yield maybeRes
-
-    /** Try to complete a request when the response arrives. */
-    protected def receiveResponse[Res <: Response](
-        response: Res
-    ): F[Unit] =
-      rpcTracker.complete(response).flatMap {
-        case Right(ok) =>
-          responseIgnored(response, None).whenA(!ok)
-        case Left(ex) =>
-          responseIgnored(response, Some(ex))
-      }
-  }
+  /** Try to complete a request when the response arrives. */
+  protected def receiveResponse[Res <: Response](
+      from: K,
+      response: Res
+  ): F[Unit] =
+    rpcTracker.complete(response).flatMap {
+      case Right(ok) =>
+        responseIgnored(from, response, None).whenA(!ok)
+      case Left(ex) =>
+        responseIgnored(from, response, Some(ex))
+    }
 }

--- a/metronome/core/src/io/iohk/metronome/core/messages/RPCSupport.scala
+++ b/metronome/core/src/io/iohk/metronome/core/messages/RPCSupport.scala
@@ -1,0 +1,110 @@
+package io.iohk.metronome.core.messages
+
+import cats.implicits._
+import cats.effect.Sync
+import scala.reflect.ClassTag
+
+/** Utility base classes to capture the pattern of interaction with `RPCTracker`.
+  * It provides send and receive methods for requests and responses.
+  */
+object RPCSupport {
+  abstract class Remote[
+      F[_]: Sync,
+      K,
+      M,
+      Request <: RPCMessageCompanion#Request,
+      Response <: RPCMessageCompanion#Response
+  ](
+      rpcTracker: RPCTracker[F, M],
+      requestId: F[RPCMessageCompanion#RequestId]
+  )(implicit ev1: Request <:< M, ev2: Response <:< M) {
+
+    protected def sendRequest: (K, Request) => F[Unit]
+
+    protected val requestTimeout: (K, Request) => F[Unit] =
+      (_, _) => ().pure[F]
+    protected val responseIgnored: (K, Response, Option[Throwable]) => F[Unit] =
+      (_, _, _) => ().pure[F]
+
+    /** Send a request to the peer and track the response.
+      *
+      * Returns `None` if we're not connected or the request times out.
+      */
+    protected def sendRequest[Req <: Request, Res <: Response](
+        to: K,
+        mkRequest: RPCMessageCompanion#RequestId => Req
+    )(implicit
+        ev: RPCPair.Aux[Req, Res],
+        ct: ClassTag[Res]
+    ): F[Option[Res]] =
+      for {
+        requestId <- requestId
+        request = mkRequest(requestId)
+        join     <- rpcTracker.register[Req, Res](request)
+        _        <- sendRequest(to, request)
+        maybeRes <- join
+        _        <- requestTimeout(to, request).whenA(maybeRes.isEmpty)
+      } yield maybeRes
+
+    /** Try to complete a request when the response arrives. */
+    protected def receiveResponse[Res <: Response](
+        from: K,
+        response: Res
+    ): F[Unit] =
+      rpcTracker.complete(response).flatMap {
+        case Right(ok) =>
+          responseIgnored(from, response, None).whenA(!ok)
+        case Left(ex) =>
+          responseIgnored(from, response, Some(ex))
+      }
+  }
+
+  /** Identical to `RPCSupport.Remote` in functionality but without support for remote address. */
+  abstract class Local[
+      F[_]: Sync,
+      M,
+      Request <: RPCMessageCompanion#Request,
+      Response <: RPCMessageCompanion#Response
+  ](
+      rpcTracker: RPCTracker[F, M],
+      requestId: F[RPCMessageCompanion#RequestId]
+  )(implicit ev1: Request <:< M, ev2: Response <:< M) {
+
+    protected def sendRequest: Request => F[Unit]
+
+    protected val requestTimeout: Request => F[Unit] =
+      _ => ().pure[F]
+    protected val responseIgnored: (Response, Option[Throwable]) => F[Unit] =
+      (_, _) => ().pure[F]
+
+    /** Send a request and track the response.
+      *
+      * Returns `None` if we're not connected or the request times out.
+      */
+    protected def sendRequest[Req <: Request, Res <: Response](
+        mkRequest: RPCMessageCompanion#RequestId => Req
+    )(implicit
+        ev: RPCPair.Aux[Req, Res],
+        ct: ClassTag[Res]
+    ): F[Option[Res]] =
+      for {
+        requestId <- requestId
+        request = mkRequest(requestId)
+        join     <- rpcTracker.register[Req, Res](request)
+        _        <- sendRequest(request)
+        maybeRes <- join
+        _        <- requestTimeout(request).whenA(maybeRes.isEmpty)
+      } yield maybeRes
+
+    /** Try to complete a request when the response arrives. */
+    protected def receiveResponse[Res <: Response](
+        response: Res
+    ): F[Unit] =
+      rpcTracker.complete(response).flatMap {
+        case Right(ok) =>
+          responseIgnored(response, None).whenA(!ok)
+        case Left(ex) =>
+          responseIgnored(response, Some(ex))
+      }
+  }
+}

--- a/metronome/examples/src/io/iohk/metronome/examples/robot/service/RobotService.scala
+++ b/metronome/examples/src/io/iohk/metronome/examples/robot/service/RobotService.scala
@@ -34,7 +34,7 @@ class RobotService[F[_]: Sync: Timer, N](
     rpcTracker: RPCTracker[F, RobotMessage],
     simulatedDecisionTime: FiniteDuration
 )(implicit storeRunner: KVStoreRunner[F, N], tracers: RobotTracers[F])
-    extends RPCSupport.Remote[
+    extends RPCSupport[
       F,
       RobotAgreement.PKey,
       RobotMessage,

--- a/metronome/examples/src/io/iohk/metronome/examples/robot/service/RobotService.scala
+++ b/metronome/examples/src/io/iohk/metronome/examples/robot/service/RobotService.scala
@@ -3,7 +3,7 @@ package io.iohk.metronome.examples.robot.service
 import cats.implicits._
 import cats.effect.{Sync, Timer, Resource, Concurrent}
 import cats.data.{NonEmptyList, NonEmptyVector, OptionT}
-import io.iohk.metronome.core.messages.RPCTracker
+import io.iohk.metronome.core.messages.{RPCTracker, RPCSupport}
 import io.iohk.metronome.crypto.ECPublicKey
 import io.iohk.metronome.crypto.hash.Hash
 import io.iohk.metronome.examples.robot.RobotAgreement
@@ -34,7 +34,16 @@ class RobotService[F[_]: Sync: Timer, N](
     rpcTracker: RPCTracker[F, RobotMessage],
     simulatedDecisionTime: FiniteDuration
 )(implicit storeRunner: KVStoreRunner[F, N], tracers: RobotTracers[F])
-    extends ApplicationService[F, RobotAgreement] {
+    extends RPCSupport.Remote[
+      F,
+      RobotAgreement.PKey,
+      RobotMessage,
+      RobotMessage with RobotMessage.Request,
+      RobotMessage with RobotMessage.Response
+    ](rpcTracker, RobotMessage.RequestId[F])
+    with ApplicationService[F, RobotAgreement] {
+
+  protected override val sendRequest = (to, req) => network.sendMessage(to, req)
 
   /** Make a random valid move on top of the last block. */
   override def createBlock(
@@ -206,13 +215,10 @@ class RobotService[F[_]: Sync: Timer, N](
       stateHash: Hash
   ): F[Option[Robot.State]] = {
     assert(from != publicKey, "Shouldn't try to get state from self.")
-    for {
-      requestId <- RobotMessage.RequestId[F]
-      request = RobotMessage.GetStateRequest(requestId, stateHash)
-      join          <- rpcTracker.register(request)
-      _             <- network.sendMessage(from, request)
-      maybeResponse <- join
-    } yield maybeResponse.map(_.state).filter(_.hash == stateHash)
+
+    sendRequest(from, RobotMessage.GetStateRequest(_, stateHash)).map {
+      _.map(_.state).filter(_.hash == stateHash)
+    }
   }
 
   private def processNetworkMessages: F[Unit] = {
@@ -242,8 +248,7 @@ class RobotService[F[_]: Sync: Timer, N](
           }
 
       case response: RobotMessage.Response =>
-        rpcTracker.complete(response).void
-
+        receiveResponse(from, response)
     }
   }
 }

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -51,7 +51,7 @@ class SyncService[F[_]: Concurrent: ContextShift, N, A <: Agreement: Block](
     incomingFiberMap: FiberMap[F, A#PKey],
     rpcTracker: RPCTracker[F, SyncMessage[A]]
 )(implicit tracers: SyncTracers[F, A], storeRunner: KVStoreRunner[F, N])
-    extends RPCSupport.Remote[
+    extends RPCSupport[
       F,
       A#PKey,
       SyncMessage[A],

--- a/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
+++ b/metronome/hotstuff/service/src/io/iohk/metronome/hotstuff/service/SyncService.scala
@@ -4,11 +4,7 @@ import cats.implicits._
 import cats.Parallel
 import cats.effect.{Sync, Resource, Concurrent, ContextShift, Timer}
 import io.iohk.metronome.core.fibers.FiberMap
-import io.iohk.metronome.core.messages.{
-  RPCMessageCompanion,
-  RPCPair,
-  RPCTracker
-}
+import io.iohk.metronome.core.messages.{RPCTracker, RPCSupport}
 import io.iohk.metronome.hotstuff.consensus.{Federation, ViewNumber}
 import io.iohk.metronome.hotstuff.consensus.basic.{
   Agreement,
@@ -32,7 +28,6 @@ import io.iohk.metronome.networking.{ConnectionHandler, Network}
 import io.iohk.metronome.storage.KVStoreRunner
 import scala.util.control.NonFatal
 import scala.concurrent.duration._
-import scala.reflect.ClassTag
 
 /** The `SyncService` handles the `SyncMessage`s coming from the network,
   * i.e. serving block and status requests, as well as receive responses
@@ -55,10 +50,24 @@ class SyncService[F[_]: Concurrent: ContextShift, N, A <: Agreement: Block](
     getState: F[ProtocolState[A]],
     incomingFiberMap: FiberMap[F, A#PKey],
     rpcTracker: RPCTracker[F, SyncMessage[A]]
-)(implicit tracers: SyncTracers[F, A], storeRunner: KVStoreRunner[F, N]) {
+)(implicit tracers: SyncTracers[F, A], storeRunner: KVStoreRunner[F, N])
+    extends RPCSupport.Remote[
+      F,
+      A#PKey,
+      SyncMessage[A],
+      SyncMessage[A] with SyncMessage.Request,
+      SyncMessage[A] with SyncMessage.Response
+    ](rpcTracker, SyncMessage.RequestId[F]) {
   import SyncMessage._
 
   type BlockSync = SyncService.BlockSynchronizerWithFiberMap[F, N, A]
+
+  protected override val sendRequest =
+    (to, req) => network.sendMessage(to, req)
+  protected override val requestTimeout =
+    (to, req) => tracers.requestTimeout((to, req))
+  protected override val responseIgnored =
+    (from, res, err) => tracers.responseIgnored((from, res, err))
 
   private def protocolStatus: F[Status[A]] =
     getState.map { state =>
@@ -72,11 +81,7 @@ class SyncService[F[_]: Concurrent: ContextShift, N, A <: Agreement: Block](
         blockStorage.get(blockHash)
       }
     } else {
-      for {
-        requestId <- RequestId[F]
-        request = GetBlockRequest(requestId, blockHash)
-        maybeResponse <- sendRequest(from, request)
-      } yield maybeResponse.map(_.block)
+      sendRequest(from, GetBlockRequest(_, blockHash)).map(_.map(_.block))
     }
 
   /** Request the status of a peer. */
@@ -84,32 +89,8 @@ class SyncService[F[_]: Concurrent: ContextShift, N, A <: Agreement: Block](
     if (from == publicKey) {
       protocolStatus.map(_.some)
     } else {
-      for {
-        requestId <- RequestId[F]
-        request = GetStatusRequest[A](requestId)
-        maybeResponse <- sendRequest(from, request)
-      } yield maybeResponse.map(_.status)
+      sendRequest(from, GetStatusRequest[A](_)).map(_.map(_.status))
     }
-
-  /** Send a request to the peer and track the response.
-    *
-    * Returns `None` if we're not connected or the request times out.
-    */
-  private def sendRequest[
-      Req <: RPCMessageCompanion#Request,
-      Res <: RPCMessageCompanion#Response
-  ](from: A#PKey, request: Req)(implicit
-      ev1: Req <:< SyncMessage[A] with SyncMessage.Request,
-      ev2: RPCPair.Aux[Req, Res],
-      ct: ClassTag[Res]
-  ): F[Option[Res]] = {
-    for {
-      join <- rpcTracker.register[Req, Res](request)
-      _    <- network.sendMessage(from, request)
-      res  <- join
-      _    <- tracers.requestTimeout(from -> request).whenA(res.isEmpty)
-    } yield res
-  }
 
   /** Process incoming network messages. */
   private def processNetworkMessages: F[Unit] = {
@@ -163,12 +144,7 @@ class SyncService[F[_]: Concurrent: ContextShift, N, A <: Agreement: Block](
           }
 
       case response: SyncMessage.Response =>
-        rpcTracker.complete(response).flatMap {
-          case Right(ok) =>
-            tracers.responseIgnored((from, response, None)).whenA(!ok)
-          case Left(ex) =>
-            tracers.responseIgnored((from, response, Some(ex)))
-        }
+        receiveResponse(from, response)
     }
 
     process.handleErrorWith { case NonFatal(ex) =>


### PR DESCRIPTION
Adds the boilerplate-y machinery to the `CheckpointingService` to:
* handle `GetStateRequest` and `GetStateResponse` in the `CheckpointinService` 
* implement the `syncState` logic

These are both like-for-like copies from the `RobotService`. Some of the request/response handling has been pulled out from all the classes that had them (`SyncService`, `RobotService`, `InterpreterClient`) so they could be reused in the `CheckpointingService`. I also separated the network message handling into a private class to limit the size of the service and the scope that has to be understood. 

Added tracing as well for the most significant events.

The PR doesn't contain any tests. They'd be rather tedious to write, and I'd rather implement https://jira.iohk.io/browse/PM-3138 in a similar fashion to https://github.com/input-output-hk/metronome/pull/44 to exercise the whole stack under simulated network conditions. We're also a bit short on time, laden with other priorities.