### PR TITLE
PM-3699: Option to return transactions to be purged during block creation

### DIFF
--- a/metronome/checkpointing/interpreter/props/src/io/iohk/metronome/checkpointing/interpreter/messages/ArbitraryInstances.scala
+++ b/metronome/checkpointing/interpreter/props/src/io/iohk/metronome/checkpointing/interpreter/messages/ArbitraryInstances.scala
@@ -39,7 +39,8 @@ object ArbitraryInstances {
       for {
         requestId <- arbitrary[UUID]
         block     <- arbitrary[Block]
-      } yield CreateBlockBodyResponse(requestId, block.body)
+        mempool   <- arbitrary[Set[Transaction.ProposerBlock]]
+      } yield CreateBlockBodyResponse(requestId, block.body, mempool)
     }
 
   implicit val arbValidateBlockBodyRequest

--- a/metronome/checkpointing/interpreter/specs/src/io/iohk/metronome/checkpointing/interpreter/InterpreterServiceSpec.scala
+++ b/metronome/checkpointing/interpreter/specs/src/io/iohk/metronome/checkpointing/interpreter/InterpreterServiceSpec.scala
@@ -104,7 +104,8 @@ object InterpreterServiceSpec {
     override def createBlockBody(
         ledger: Ledger,
         mempool: Seq[Transaction.ProposerBlock]
-    ): Task[Option[Block.Body]] = Task.pure(None)
+    ): Task[Option[(Block.Body, Set[Transaction.ProposerBlock])]] =
+      Task.pure(None)
 
     override def validateBlockBody(
         blockBody: Block.Body,

--- a/metronome/checkpointing/interpreter/specs/src/io/iohk/metronome/checkpointing/interpreter/InterpreterServiceSpec.scala
+++ b/metronome/checkpointing/interpreter/specs/src/io/iohk/metronome/checkpointing/interpreter/InterpreterServiceSpec.scala
@@ -104,7 +104,7 @@ object InterpreterServiceSpec {
     override def createBlockBody(
         ledger: Ledger,
         mempool: Seq[Transaction.ProposerBlock]
-    ): Task[Option[(Block.Body, Set[Transaction.ProposerBlock])]] =
+    ): Task[Option[InterpreterRPC.CreateResult]] =
       Task.pure(None)
 
     override def validateBlockBody(

--- a/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/InterpreterRPC.scala
+++ b/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/InterpreterRPC.scala
@@ -26,7 +26,7 @@ trait InterpreterRPC[F[_]] {
   def createBlockBody(
       ledger: Ledger,
       mempool: Seq[Transaction.ProposerBlock]
-  ): F[Option[(Block.Body, Set[Transaction.ProposerBlock])]]
+  ): F[Option[InterpreterRPC.CreateResult]]
 
   def validateBlockBody(
       blockBody: Block.Body,
@@ -36,4 +36,23 @@ trait InterpreterRPC[F[_]] {
   def newCheckpointCertificate(
       checkpointCertificate: CheckpointCertificate
   ): F[Unit]
+}
+
+object InterpreterRPC {
+
+  /** The block body created by the interpreter with an optional
+    * set of items to unconditionally purge from the mempool.
+    */
+  type CreateResult = (Block.Body, Set[Transaction.ProposerBlock])
+
+  object CreateResult {
+    val empty: CreateResult =
+      (Block.Body.empty, Set.empty)
+
+    def apply(
+        blockBody: Block.Body,
+        purgeFromMempool: Set[Transaction.ProposerBlock] = Set.empty
+    ): CreateResult =
+      blockBody -> purgeFromMempool
+  }
 }

--- a/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/InterpreterRPC.scala
+++ b/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/InterpreterRPC.scala
@@ -26,7 +26,7 @@ trait InterpreterRPC[F[_]] {
   def createBlockBody(
       ledger: Ledger,
       mempool: Seq[Transaction.ProposerBlock]
-  ): F[Option[Block.Body]]
+  ): F[Option[(Block.Body, Set[Transaction.ProposerBlock])]]
 
   def validateBlockBody(
       blockBody: Block.Body,

--- a/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/codecs/DefaultInterpreterCodecs.scala
+++ b/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/codecs/DefaultInterpreterCodecs.scala
@@ -31,6 +31,9 @@ trait DefaultInterpreterCodecs {
   private implicit def `Codec[Seq[T]]`[T: Codec]: Codec[Seq[T]] =
     Codec[List[T]].xmap(_.toSeq, _.toList)
 
+  private implicit def `Codec[Set[T]]`[T: Codec]: Codec[Set[T]] =
+    Codec[List[T]].xmap(_.toSet, _.toList)
+
   implicit val newProposerBlockRequestCodec: Codec[NewProposerBlockRequest] =
     Codec.deriveLabelledGeneric
 

--- a/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/messages/InterpreterMessage.scala
+++ b/metronome/checkpointing/interpreter/src/io/iohk/metronome/checkpointing/interpreter/messages/InterpreterMessage.scala
@@ -102,10 +102,16 @@ object InterpreterMessage extends RPCMessageCompanion {
     * nothing to do, so the Service can either propose an empty block
     * to keep everyone in sync, or just move to the next leader by
     * other means.
+    *
+    * The response can also contain a set of mempool items that
+    * should be permanently removed, because they will never be
+    * included in a block body. This should prevent pending
+    * transactions lingering forever in memory.
     */
   case class CreateBlockBodyResponse(
       requestId: RequestId,
-      blockBody: Block.Body
+      blockBody: Block.Body,
+      purgeFromMempool: Set[Transaction.ProposerBlock]
   ) extends InterpreterMessage
       with Response
       with FromInterpreter

--- a/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/BlockCreationProps.scala
+++ b/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/BlockCreationProps.scala
@@ -14,6 +14,7 @@ import monix.eval.Task
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.{all, forAll, propBoolean}
 import org.scalacheck.{Gen, Properties}
+import io.iohk.metronome.checkpointing.interpreter.InterpreterRPC
 
 /** Props for CheckpointingService focusing on `createBlock` */
 object BlockCreationProps extends Properties("BlockCreation") {
@@ -44,10 +45,10 @@ object BlockCreationProps extends Properties("BlockCreation") {
       override def createBlockBody(
           ledger: Ledger,
           mempool: Seq[ProposerBlock]
-      ) =
+      ): Task[Option[InterpreterRPC.CreateResult]] =
         recordedArguments
           .set((ledger, mempool).some)
-          .as(createdBody.map(_ -> Set.empty))
+          .as(createdBody.map(InterpreterRPC.CreateResult(_)))
     }
 
     override val interpreterClientResource: Resource[Task, InterpreterClient] =

--- a/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/BlockCreationProps.scala
+++ b/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/BlockCreationProps.scala
@@ -44,8 +44,10 @@ object BlockCreationProps extends Properties("BlockCreation") {
       override def createBlockBody(
           ledger: Ledger,
           mempool: Seq[ProposerBlock]
-      ): Task[Option[Block.Body]] =
-        recordedArguments.set((ledger, mempool).some).map(_ => createdBody)
+      ) =
+        recordedArguments
+          .set((ledger, mempool).some)
+          .as(createdBody.map(_ -> Set.empty))
     }
 
     override val interpreterClientResource: Resource[Task, InterpreterClient] =

--- a/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
+++ b/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
@@ -62,8 +62,7 @@ object CheckpointingServiceFixtures {
     override def createBlockBody(
         ledger: Ledger,
         mempool: Seq[Transaction.ProposerBlock]
-    ): Task[Option[(Block.Body, Set[Transaction.ProposerBlock])]] =
-      Task.pure(None)
+    ): Task[Option[InterpreterRPC.CreateResult]] = Task.pure(none)
 
     override def validateBlockBody(
         blockBody: Block.Body,

--- a/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
+++ b/metronome/checkpointing/service/props/src/io/iohk/metronome/checkpointing/service/CheckpointingServiceFixtures.scala
@@ -62,7 +62,7 @@ object CheckpointingServiceFixtures {
     override def createBlockBody(
         ledger: Ledger,
         mempool: Seq[Transaction.ProposerBlock]
-    ): Task[Option[Block.Body]] =
+    ): Task[Option[(Block.Body, Set[Transaction.ProposerBlock])]] =
       Task.pure(None)
 
     override def validateBlockBody(

--- a/metronome/checkpointing/service/specs/src/io/iohk/metronome/checkpointing/service/InterpreterClientSpec.scala
+++ b/metronome/checkpointing/service/specs/src/io/iohk/metronome/checkpointing/service/InterpreterClientSpec.scala
@@ -136,10 +136,11 @@ class InterpreterClientSpec extends AnyFlatSpec with Matchers with Inspectors {
           _ <- awaitProcessing()
 
           sb = sample[Block].body
+          sp = sample[Set[Transaction.ProposerBlock]]
           iv = true
           _ <- input.connection.processOutgoingMessages {
             case CreateBlockBodyRequest(requestId, _, _) =>
-              CreateBlockBodyResponse(requestId, sb)
+              CreateBlockBodyResponse(requestId, sb, sp)
             case ValidateBlockBodyRequest(requestId, _, _) =>
               ValidateBlockBodyResponse(requestId, iv)
           }
@@ -150,7 +151,7 @@ class InterpreterClientSpec extends AnyFlatSpec with Matchers with Inspectors {
           r1 <- w1.join
           r2 <- w2.join
         } yield {
-          r1 shouldBe Some(sb)
+          r1 shouldBe Some(sb -> sp)
           r2 shouldBe Some(iv)
         }
     }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
@@ -63,7 +63,7 @@ class CheckpointingService[F[_]: Sync, N](
 
       (newBody, toPurge) <- OptionT {
         if (mempool.isEmpty && config.expectCheckpointCandidateNotifications)
-          (Block.Body.empty, Set.empty[Transaction.ProposerBlock]).some.pure[F]
+          InterpreterRPC.CreateResult.empty.some.pure[F]
         else
           interpreterClient.createBlockBody(oldLedger, mempool.proposerBlocks)
       }

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/CheckpointingService.scala
@@ -61,9 +61,9 @@ class CheckpointingService[F[_]: Sync, N](
       oldLedger <- OptionT(projectLedger(parent))
       mempool   <- OptionT.liftF(projectMempool(highQC.blockHash))
 
-      newBody <- OptionT {
+      (newBody, toPurge) <- OptionT {
         if (mempool.isEmpty && config.expectCheckpointCandidateNotifications)
-          Block.Body.empty.some.pure[F]
+          (Block.Body.empty, Set.empty[Transaction.ProposerBlock]).some.pure[F]
         else
           interpreterClient.createBlockBody(oldLedger, mempool.proposerBlocks)
       }
@@ -72,6 +72,7 @@ class CheckpointingService[F[_]: Sync, N](
       newBlock  = Block.make(parent.header, newLedger.hash, newBody)
 
       _ <- OptionT.liftF(updateLedgerTree(newLedger, newBlock.header))
+      _ <- OptionT.liftF(removeFromMempool(toPurge))
       _ <- OptionT.liftF(tracer(CheckpointingEvent.Proposing(newBlock)))
     } yield newBlock
   ).value
@@ -117,6 +118,7 @@ class CheckpointingService[F[_]: Sync, N](
               }
               .toOptionT[F]
 
+            // TODO: PM-3107: Filter mempool.
             tracer(CheckpointingEvent.NewState(ledger)) >>
               saveLedger(block.header, ledger) >>
               certificateOpt.cataF(
@@ -190,6 +192,14 @@ class CheckpointingService[F[_]: Sync, N](
     */
   private def projectMempool(blockHash: Block.Hash): F[Mempool] =
     mempoolRef.getAndUpdate(_.clearCheckpointCandidate)
+
+  /** Remove items from the mempool that will no longer be included in a block. */
+  private def removeFromMempool(
+      items: Set[Transaction.ProposerBlock]
+  ): F[Unit] =
+    mempoolRef
+      .update(p => p.copy(proposerBlocks = p.proposerBlocks.filterNot(items)))
+      .whenA(items.nonEmpty)
 
   /** Saves a new ledger in the tree only if a parent state exists.
     * Because we're only adding to the tree no locking around it is necessary

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/InterpreterClient.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/InterpreterClient.scala
@@ -48,9 +48,9 @@ object InterpreterClient {
     override def createBlockBody(
         ledger: Ledger,
         mempool: Seq[Transaction.ProposerBlock]
-    ): F[Option[Block.Body]] =
+    ): F[Option[(Block.Body, Set[Transaction.ProposerBlock])]] =
       sendRequest((), CreateBlockBodyRequest(_, ledger, mempool)).map {
-        _.map(_.blockBody)
+        _.map(r => (r.blockBody, r.purgeFromMempool))
       }
 
     override def validateBlockBody(

--- a/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/InterpreterClient.scala
+++ b/metronome/checkpointing/service/src/io/iohk/metronome/checkpointing/service/InterpreterClient.scala
@@ -48,7 +48,7 @@ object InterpreterClient {
     override def createBlockBody(
         ledger: Ledger,
         mempool: Seq[Transaction.ProposerBlock]
-    ): F[Option[(Block.Body, Set[Transaction.ProposerBlock])]] =
+    ): F[Option[InterpreterRPC.CreateResult]] =
       sendRequest((), CreateBlockBodyRequest(_, ledger, mempool)).map {
         _.map(r => (r.blockBody, r.purgeFromMempool))
       }


### PR DESCRIPTION
Adds the ability for the Interpreter to signal to the Service that some transactions in the mempool can be unconditionally forgotten.

Normally we'd keep the transactions in the mempool until a block that contains them is executed, however, some transactions may be there that can never be included in a block. Since `CreateBlockBodyRequest` contains the `mempool`, `CreateBlockBodyResponse` can be used to signal that some of the content has been inspected and is no longer interesting.